### PR TITLE
feat: add NEBULENTO_PIPELINE and PALAVREADO_PIPELINE stage groups

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -75,6 +75,11 @@ M2V_PIPELINE = [
     "ovos-m2v-pipeline-medium",
     "ovos-m2v-pipeline-low",
 ]
+# Nebulento — fuzzy intent matching (ConfidenceMatcherPipeline). Single OPM
+# entry point; the pipeline manager handles confidence-tier routing.
+NEBULENTO_PIPELINE = ["ovos-nebulento-pipeline-plugin"]
+# Palavreado — keyword/slot intent parser (ConfidenceMatcherPipeline).
+PALAVREADO_PIPELINE = ["palavreado"]
 
 # Standard test pipeline — all standard built-in stages.
 # This requires ovos-adapt-pipeline-plugin and ovos-padatious-pipeline-plugin.


### PR DESCRIPTION
## Summary

- Add `NEBULENTO_PIPELINE = ["ovos-nebulento-pipeline-plugin"]` and `PALAVREADO_PIPELINE = ["palavreado"]` constants alongside the existing `ADAPT_PIPELINE` / `PADATIOUS_PIPELINE` / `M2V_PIPELINE` blocks in `ovoscope/__init__.py`.
- Both engines already implement `ConfidenceMatcherPipeline` and register single-name OPM entry points, so each constant is a single-element list — no harness changes required.
- Opt-in only: `DEFAULT_TEST_PIPELINE` is unchanged.

## Test plan

- [ ] `python -c "from ovoscope import NEBULENTO_PIPELINE, PALAVREADO_PIPELINE; print(NEBULENTO_PIPELINE, PALAVREADO_PIPELINE)"` prints the two lists
- [ ] Existing test suite still passes
- [ ] Downstream `nebulento` / `palavreado` e2e tests can import the constants

## AI Usage Disclaimer

claude-opus-4-7. Human reviewed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new pipeline stage configurations for enhanced intent recognition and text parsing capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/ovoscope/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->