### PR TITLE
feat(intent-cases): markdown reporter, baseline diff, auto-discovery, deterministic m2v warmup

### DIFF
--- a/ovoscope/intent_cases.py
+++ b/ovoscope/intent_cases.py
@@ -253,11 +253,72 @@ def assert_intent_case(minicroft, skill_id: str, handlers: Dict[str, str],
 _SHARED_MINICROFT_KEY = "_ovoscope_shared_minicroft"
 
 
+def _wait_for_m2v_sync(mc, max_wait: float = 15.0,
+                       quiet_window: float = 0.5) -> float:
+    """Wait deterministically for the m2v pipeline to finish its
+    ``handle_sync_intents`` debounce after ``mycroft.ready``.
+
+    The m2v plugin (`ovos_m2v_pipeline/__init__.py:handle_sync_intents`)
+    sleeps 3 s then re-queries the adapt + padatious intent manifests.
+    Until that returns, the pipeline matches against an empty label set
+    and every utterance falls through. We avoid relying on a fixed
+    ``time.sleep`` by:
+
+      1. Subscribing to every ``padatious:register_intent`` /
+         ``register_intent`` event on the bus.
+      2. Emitting ``mycroft.ready`` (which triggers
+         ``handle_sync_intents``).
+      3. Waiting until no new register events have arrived for
+         ``quiet_window`` seconds AND at least one register event has
+         actually been observed (or ``max_wait`` is exhausted).
+      4. Adding a small constant grace period for the in-plugin
+         ``time.sleep(3)`` debounce to actually return.
+
+    Returns the seconds slept (for diagnostics).
+    """
+    seen = {"count": 0, "last_t": 0.0}
+
+    def on_register(_serialized):
+        seen["count"] += 1
+        seen["last_t"] = time.monotonic()
+
+    mc.bus.ee.on("padatious:register_intent",
+                 lambda _: on_register(None))
+    mc.bus.ee.on("register_intent", lambda _: on_register(None))
+
+    # Wildcard "message" listener catches the serialized form on FakeBus.
+    def on_any(serialized):
+        try:
+            t = serialized.get("type") if isinstance(serialized, dict) else None
+        except Exception:
+            return
+        if not t:
+            return
+        if t == "padatious:register_intent" or t == "register_intent":
+            on_register(None)
+
+    mc.bus.ee.on("message", on_any)
+
+    t0 = time.monotonic()
+    mc.bus.emit(Message("mycroft.ready", {}, {}))
+
+    # Wait for the burst of register events to settle.
+    while time.monotonic() - t0 < max_wait:
+        time.sleep(0.1)
+        if seen["count"] > 0 and (time.monotonic() - seen["last_t"]) > quiet_window:
+            break
+    # m2v's handle_sync_intents does an internal time.sleep(3) before the
+    # actual intent set update. Pad for that ceiling.
+    time.sleep(3.5)
+    return time.monotonic() - t0
+
+
 def _shared_minicroft(skill_id: str, langs: List[str], m2v_warmup: float):
     """Lazily create one MiniCroft and warm m2v's label index.
 
     Caches the instance on a process-global so every generated class
-    shares the same boot.
+    shares the same boot. ``m2v_warmup`` is now an *upper bound*: if the
+    deterministic event-based wait finishes faster, we return early.
     """
     cache = globals().setdefault(_SHARED_MINICROFT_KEY, {})
     key = (skill_id, tuple(langs))
@@ -265,13 +326,15 @@ def _shared_minicroft(skill_id: str, langs: List[str], m2v_warmup: float):
         LOG.set_level("CRITICAL")
         secondary = [l for l in langs if l != "en-US"]
         mc = get_minicroft([skill_id], secondary_langs=secondary or None)
-        # m2v consumes ``padatious:register_intent`` to (re)build its label
-        # index; ``mycroft.ready`` triggers ``handle_sync_intents``. Without
-        # this nudge the first m2v call logs "No model classes match
-        # registered intents" and falls through.
-        mc.bus.emit(Message("mycroft.ready", {}, {}))
         if m2v_warmup > 0:
-            time.sleep(m2v_warmup)
+            try:
+                _wait_for_m2v_sync(mc, max_wait=max(m2v_warmup, 5.0))
+            except Exception:
+                # If the deterministic wait fails for any reason
+                # (e.g. FakeBus internals change), fall back to a sleep
+                # so the suite still runs.
+                mc.bus.emit(Message("mycroft.ready", {}, {}))
+                time.sleep(m2v_warmup)
         cache[key] = mc
     return cache[key]
 
@@ -379,4 +442,66 @@ def register_intent_case_tests(
                                 doc)
         target_globals[cls_name] = cls
         created[cls_name] = cls
+    # Mark generated classes so the pytest auto-discovery hook can skip a
+    # cases_dir whose tests are already registered by an explicit call.
+    target_globals["_ovoscope_intent_cases_registered"] = True
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Pytest auto-discovery (no Python boilerplate required in the skill).
+#
+# A skill can opt in by adding a ``conftest.py`` next to its
+# ``cases/`` directory containing:
+#
+#     ovoscope_intent_cases = dict(
+#         skill_id="my-skill.author",
+#         handlers={"DoX.intent": "MySkill.handle_do_x", ...},
+#     )
+#
+# The ``pytest_collect_directory`` hook on the ovoscope pytest plugin
+# discovers the conftest, walks ``<dir>/cases/`` and generates the same
+# TestCase classes ``register_intent_case_tests`` would have created —
+# zero boilerplate in the test module.
+# ---------------------------------------------------------------------------
+def autodiscover_from_conftest(conftest_dir: Union[str, Path],
+                               target_globals: dict) -> Dict[str, type]:
+    """Look for ``ovoscope_intent_cases`` config in a conftest namespace
+    and call :func:`register_intent_case_tests` accordingly.
+
+    The conftest must expose a dict like::
+
+        ovoscope_intent_cases = {
+            "skill_id": "my-skill.author",
+            "handlers": {"WhoAreYou.intent": "MySkill.handle_who", ...},
+            # optional overrides:
+            "cases_dir": "cases",
+            "pipelines": {"Custom": [...]},
+            "ignore_messages": [...],
+            "timeout": 30,
+            "m2v_warmup": 10.0,
+        }
+
+    Returns ``{}`` if the conftest has no ``ovoscope_intent_cases`` or
+    the cases directory does not exist.
+    """
+    cfg = target_globals.get("ovoscope_intent_cases")
+    if not cfg:
+        return {}
+    base = Path(conftest_dir)
+    cases_dir = Path(cfg.get("cases_dir", "cases"))
+    if not cases_dir.is_absolute():
+        cases_dir = base / cases_dir
+    if not cases_dir.is_dir():
+        return {}
+    return register_intent_case_tests(
+        target_globals,
+        skill_id=cfg["skill_id"],
+        handlers=cfg["handlers"],
+        cases_dir=cases_dir,
+        pipelines=cfg.get("pipelines"),
+        ignore_messages=cfg.get("ignore_messages"),
+        timeout=cfg.get("timeout", 30),
+        m2v_warmup=cfg.get("m2v_warmup", 10.0),
+    )
     return created

--- a/ovoscope/pytest_plugin.py
+++ b/ovoscope/pytest_plugin.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 if TYPE_CHECKING:
     from ovoscope.bus_coverage import BusCoverageReport
 
+from pathlib import Path
+
 import pytest
 
 from ovoscope import MiniCroft, get_minicroft, End2EndTest
@@ -130,6 +132,24 @@ def pytest_addoption(parser):
               "don't fail the build; only the aggregate accuracy gate "
               "(--ovoscope-accuracy-min / --ovoscope-accuracy-baseline) "
               "can block the session."),
+    )
+    group.addoption(
+        "--ovoscope-accuracy-md",
+        action="store",
+        default=None,
+        metavar="PATH",
+        help=("Write a Markdown intent-case accuracy report (the format "
+              "consumed by the OpenVoiceOS gh-automations PR-comment "
+              "workflow). Pairs naturally with --ovoscope-accuracy-report."),
+    )
+    group.addoption(
+        "--ovoscope-accuracy-top-n",
+        action="store",
+        type=int,
+        default=10,
+        metavar="N",
+        help=("Show the N hardest utterances (lowest cross-pipeline pass "
+              "rate) in the Markdown report. Default: 10."),
     )
 
 
@@ -377,6 +397,45 @@ def _resolve_intent_case_meta(item):
             getattr(func, "_intent_case_skill_id", ""))
 
 
+def pytest_configure(config):
+    """Auto-discover ``ovoscope_intent_cases`` declarations in conftest
+    modules so skills don't need to write any Python in their test files.
+
+    Walks every collected ``conftest`` module looking for a top-level
+    ``ovoscope_intent_cases`` dict; for each one found, generates the
+    full set of intent-case TestCase classes inside that conftest's
+    namespace. Skills already calling
+    :func:`ovoscope.intent_cases.register_intent_case_tests` explicitly
+    are unaffected (the explicit call marks the module as registered).
+    """
+    import sys
+    from ovoscope.intent_cases import autodiscover_from_conftest
+    # We can't enumerate conftests directly until collection runs; instead
+    # piggy-back on the already-imported sys.modules. The pytest config
+    # phase runs after rootdir-conftests have imported, so any top-level
+    # `ovoscope_intent_cases = {...}` is already in sys.modules.
+    for mod in list(sys.modules.values()):
+        if mod is None or not hasattr(mod, "__file__"):
+            continue
+        try:
+            if not getattr(mod, "__file__", "").endswith("conftest.py"):
+                continue
+        except (AttributeError, TypeError):
+            continue
+        if getattr(mod, "_ovoscope_intent_cases_registered", False):
+            continue
+        try:
+            autodiscover_from_conftest(
+                Path(mod.__file__).parent,
+                mod.__dict__,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Non-fatal: a malformed config shouldn't prevent collection;
+            # surface in the logs instead.
+            print(f"ovoscope auto-discovery skipped for {mod.__file__}: "
+                  f"{exc}")
+
+
 def pytest_collection_modifyitems(config, items):
     """In tolerant mode, mark every intent-case test as ``xfail(strict=False)``.
 
@@ -440,10 +499,18 @@ def pytest_runtest_setup(item):
 
 
 def _accuracy_summary(results):
-    """Aggregate results into pivot tables for reporting."""
+    """Aggregate results into pivot tables for reporting.
+
+    Adds, on top of the previous pivots, a per-utterance roll-up that
+    feeds the "hardest utterances" section of the Markdown report.
+    """
     by_pipeline: Dict[str, Dict[str, int]] = {}
     by_pipeline_lang: Dict[tuple, Dict[str, int]] = {}
     by_pipeline_intent: Dict[tuple, Dict[str, int]] = {}
+    # Cross-pipeline rollup: (lang, intent, utterance) -> {pass, total,
+    # failing_pipelines}. Lets us surface "which exact phrasing routes
+    # poorly across the whole stack" in one place.
+    by_utterance: Dict[tuple, Dict[str, object]] = {}
     total_pass = total = 0
     for r in results:
         total += 1
@@ -458,6 +525,16 @@ def _accuracy_summary(results):
             d["total"] += 1
             if r["passed"]:
                 d["pass"] += 1
+        utt_key = (r["lang"], r["intent"], r["utterance"])
+        u = by_utterance.setdefault(utt_key, {
+            "lang": r["lang"], "intent": r["intent"],
+            "utterance": r["utterance"],
+            "pass": 0, "total": 0, "failing_pipelines": []})
+        u["total"] += 1
+        if r["passed"]:
+            u["pass"] += 1
+        else:
+            u["failing_pipelines"].append(r["pipeline"])
     overall = (total_pass / total) if total else 0.0
     return {
         "overall_accuracy": overall,
@@ -466,7 +543,177 @@ def _accuracy_summary(results):
         "by_pipeline": by_pipeline,
         "by_pipeline_lang": {f"{p}|{l}": v for (p, l), v in by_pipeline_lang.items()},
         "by_pipeline_intent": {f"{p}|{i}": v for (p, i), v in by_pipeline_intent.items()},
+        "by_utterance": list(by_utterance.values()),
     }
+
+
+# ---------------------------------------------------------------------------
+# Baseline diff
+# ---------------------------------------------------------------------------
+def _result_key(r: dict) -> tuple:
+    """Stable identity for a single (pipeline, lang, intent, utterance) case."""
+    return (r.get("pipeline", ""), r.get("lang", ""),
+            r.get("intent", ""), r.get("utterance", ""))
+
+
+def _baseline_diff(baseline_results, current_results):
+    """Compare two result lists by case key, returning a structural diff.
+
+    Returns ``{"regressed": [...], "recovered": [...], "added": [...],
+    "removed": [...], "baseline_accuracy": float}``. Each item in
+    ``regressed`` / ``recovered`` is the matching *current* result dict
+    so callers can quote the offending utterance verbatim.
+    """
+    base_by_key = {_result_key(r): r for r in baseline_results or []}
+    cur_by_key = {_result_key(r): r for r in current_results or []}
+
+    regressed, recovered, added, removed = [], [], [], []
+    for k, cur in cur_by_key.items():
+        if k not in base_by_key:
+            added.append(cur)
+            continue
+        base = base_by_key[k]
+        if base.get("passed") and not cur.get("passed"):
+            regressed.append(cur)
+        elif (not base.get("passed")) and cur.get("passed"):
+            recovered.append(cur)
+    for k, base in base_by_key.items():
+        if k not in cur_by_key:
+            removed.append(base)
+
+    base_total = len(baseline_results or [])
+    base_pass = sum(1 for r in (baseline_results or []) if r.get("passed"))
+    base_acc = (base_pass / base_total) if base_total else 0.0
+
+    return {
+        "regressed": regressed, "recovered": recovered,
+        "added": added, "removed": removed,
+        "baseline_accuracy": base_acc, "baseline_passed": base_pass,
+        "baseline_total": base_total,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown report
+# ---------------------------------------------------------------------------
+def _accuracy_markdown(summary, results, baseline_diff=None, top_n=10):
+    """Render the intent-case accuracy summary as Markdown.
+
+    Mirrors the table-and-collapsible-section style used by the existing
+    bus-coverage section in the gh-automations PR-comment workflow:
+    headline line, summary table, per-(pipeline,lang) and
+    per-(pipeline,intent) breakdowns in ``<details>`` blocks, then a
+    "hardest utterances" call-out and, when present, a baseline diff.
+    """
+    overall = summary["overall_accuracy"]
+    icon = "✅" if overall >= 0.9 else ("⚠️" if overall >= 0.7 else "❌")
+    lines = [
+        f"{icon} **{summary['passed']}/{summary['total']}** intent-case "
+        f"checks passed — overall accuracy **{overall:.1%}**.",
+        "",
+    ]
+
+    # --- Per-pipeline summary table (always visible) ---
+    lines.append("| Pipeline | Pass / Total | Accuracy |")
+    lines.append("|---|---:|---:|")
+    for pipe, d in sorted(summary["by_pipeline"].items()):
+        ratio = d["pass"] / d["total"] if d["total"] else 0.0
+        lines.append(f"| `{pipe}` | {d['pass']} / {d['total']} | {ratio:.1%} |")
+    lines.append("")
+
+    # --- Per-(pipeline, lang) ---
+    lines.append("<details><summary>Per-pipeline × language</summary>")
+    lines.append("")
+    lines.append("| Pipeline | Lang | Pass / Total | Accuracy |")
+    lines.append("|---|---|---:|---:|")
+    for key in sorted(summary["by_pipeline_lang"]):
+        pipe, lang = key.split("|", 1)
+        d = summary["by_pipeline_lang"][key]
+        ratio = d["pass"] / d["total"] if d["total"] else 0.0
+        lines.append(f"| `{pipe}` | `{lang}` | {d['pass']} / {d['total']} | {ratio:.1%} |")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+    # --- Per-(pipeline, intent) ---
+    lines.append("<details><summary>Per-pipeline × intent</summary>")
+    lines.append("")
+    lines.append("| Pipeline | Intent | Pass / Total | Accuracy |")
+    lines.append("|---|---|---:|---:|")
+    for key in sorted(summary["by_pipeline_intent"]):
+        pipe, intent = key.split("|", 1)
+        d = summary["by_pipeline_intent"][key]
+        ratio = d["pass"] / d["total"] if d["total"] else 0.0
+        lines.append(f"| `{pipe}` | `{intent}` | {d['pass']} / {d['total']} | {ratio:.1%} |")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+    # --- Hardest utterances (lowest cross-pipeline pass rate) ---
+    utts = list(summary.get("by_utterance", []))
+    # Only utterances that failed at least once and aren't no_match
+    hard = [u for u in utts
+            if u["total"] > 0 and u["pass"] < u["total"]
+            and u["intent"] != "no_match"]
+    hard.sort(key=lambda u: (u["pass"] / u["total"], -u["total"]))
+    if hard:
+        lines.append(f"<details><summary>Hardest utterances "
+                     f"(top {min(top_n, len(hard))})</summary>")
+        lines.append("")
+        lines.append("| Lang | Intent | Utterance | Pass / Total | Failing pipelines |")
+        lines.append("|---|---|---|---:|---|")
+        for u in hard[:top_n]:
+            fail_pipes = ", ".join(f"`{p}`" for p in sorted(set(u["failing_pipelines"])))
+            lines.append(f"| `{u['lang']}` | `{u['intent']}` "
+                         f"| {u['utterance']} "
+                         f"| {u['pass']} / {u['total']} | {fail_pipes} |")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    # --- Baseline diff (when supplied) ---
+    if baseline_diff is not None:
+        regressed = baseline_diff["regressed"]
+        recovered = baseline_diff["recovered"]
+        delta = overall - baseline_diff["baseline_accuracy"]
+        delta_str = f"{delta:+.1%}"
+        head = (f"vs baseline ({baseline_diff['baseline_passed']}/"
+                f"{baseline_diff['baseline_total']} = "
+                f"{baseline_diff['baseline_accuracy']:.1%}): "
+                f"{len(regressed)} regressed, {len(recovered)} recovered, "
+                f"Δ {delta_str}")
+        lines.append(f"**Baseline diff** — {head}")
+        lines.append("")
+        if regressed:
+            lines.append("<details open><summary>❌ Regressed "
+                         f"({len(regressed)})</summary>")
+            lines.append("")
+            lines.append("| Pipeline | Lang | Intent | Utterance |")
+            lines.append("|---|---|---|---|")
+            for r in regressed[:50]:
+                lines.append(f"| `{r['pipeline']}` | `{r['lang']}` | "
+                             f"`{r['intent']}` | {r['utterance']} |")
+            if len(regressed) > 50:
+                lines.append(f"| … | … | … | _+{len(regressed)-50} more_ |")
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+        if recovered:
+            lines.append("<details><summary>✅ Recovered "
+                         f"({len(recovered)})</summary>")
+            lines.append("")
+            lines.append("| Pipeline | Lang | Intent | Utterance |")
+            lines.append("|---|---|---|---|")
+            for r in recovered[:50]:
+                lines.append(f"| `{r['pipeline']}` | `{r['lang']}` | "
+                             f"`{r['intent']}` | {r['utterance']} |")
+            if len(recovered) > 50:
+                lines.append(f"| … | … | … | _+{len(recovered)-50} more_ |")
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):  # noqa: ARG001
@@ -500,43 +747,79 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):  # noqa: ARG0
         ratio = d["pass"] / d["total"] if d["total"] else 0.0
         tr.write_line(f"  {key:48s}  {d['pass']:4d}/{d['total']:<4d}  {ratio:>6.1%}")
 
-    # Persist to JSON if requested.
+    # Load baseline (if any) and compute structural diff up-front so both
+    # the JSON / Markdown outputs and the gate can reuse it.
+    baseline_path = config.getoption("--ovoscope-accuracy-baseline")
+    baseline_diff = None
+    baseline_warning = None
+    if baseline_path:
+        try:
+            import json as _json
+            with open(baseline_path, "r", encoding="utf-8") as fh:
+                baseline_doc = _json.load(fh)
+            baseline_diff = _baseline_diff(
+                baseline_doc.get("results") or [],
+                accum["results"])
+        except Exception as exc:
+            baseline_warning = (f"could not read baseline "
+                                f"{baseline_path}: {exc}")
+            tr.write_line(f"\nWARNING: {baseline_warning}")
+
+    # Persist JSON.
     report_path = config.getoption("--ovoscope-accuracy-report")
     if report_path:
         import json
         import os
         os.makedirs(os.path.dirname(os.path.abspath(report_path)) or ".",
                     exist_ok=True)
+        doc = {"summary": summary, "results": accum["results"]}
+        if baseline_diff is not None:
+            doc["baseline_diff"] = {
+                "regressed": baseline_diff["regressed"],
+                "recovered": baseline_diff["recovered"],
+                "added": baseline_diff["added"],
+                "removed": baseline_diff["removed"],
+                "baseline_accuracy": baseline_diff["baseline_accuracy"],
+                "baseline_passed": baseline_diff["baseline_passed"],
+                "baseline_total": baseline_diff["baseline_total"],
+            }
         with open(report_path, "w", encoding="utf-8") as fh:
-            json.dump({"summary": summary, "results": accum["results"]},
-                      fh, indent=2)
+            json.dump(doc, fh, indent=2)
         tr.write_line(f"\nWrote accuracy report -> {report_path}")
 
-    # Gate the session on minimum / baseline accuracy.
+    # Persist Markdown (for PR-comment ingestion).
+    md_path = config.getoption("--ovoscope-accuracy-md")
+    if md_path:
+        import os
+        os.makedirs(os.path.dirname(os.path.abspath(md_path)) or ".",
+                    exist_ok=True)
+        top_n = config.getoption("--ovoscope-accuracy-top-n")
+        md = _accuracy_markdown(summary, accum["results"],
+                                baseline_diff=baseline_diff, top_n=top_n)
+        with open(md_path, "w", encoding="utf-8") as fh:
+            fh.write(md)
+        tr.write_line(f"Wrote accuracy markdown -> {md_path}")
+
+    # Gate the session.
     min_acc = config.getoption("--ovoscope-accuracy-min")
-    baseline_path = config.getoption("--ovoscope-accuracy-baseline")
     failures = []
     if min_acc is not None and summary["overall_accuracy"] < min_acc:
         failures.append(
             f"overall accuracy {summary['overall_accuracy']:.1%} < "
             f"required {min_acc:.1%}")
-    if baseline_path:
-        try:
-            import json as _json
-            with open(baseline_path, "r", encoding="utf-8") as fh:
-                base = _json.load(fh)["summary"]["overall_accuracy"]
-            if summary["overall_accuracy"] < base:
-                failures.append(
-                    f"overall accuracy {summary['overall_accuracy']:.1%} < "
-                    f"baseline {base:.1%} ({baseline_path})")
-        except Exception as exc:
-            tr.write_line(f"\nWARNING: could not read baseline "
-                          f"{baseline_path}: {exc}")
+    if baseline_diff is not None:
+        if baseline_diff["regressed"]:
+            top_regression = baseline_diff["regressed"][0]
+            failures.append(
+                f"{len(baseline_diff['regressed'])} cases regressed vs "
+                f"baseline (first: `{top_regression['pipeline']}` / "
+                f"`{top_regression['lang']}` / "
+                f"`{top_regression['intent']}` / "
+                f"{top_regression['utterance']!r})")
     if failures:
         tr.write_sep("!", "ovoscope accuracy gate FAILED")
         for f in failures:
             tr.write_line(f"  - {f}")
-        # Mark the session as failed.
         config._ovoscope_accuracy_gate_failed = True
 
 

--- a/ovoscope/pytest_plugin.py
+++ b/ovoscope/pytest_plugin.py
@@ -397,43 +397,57 @@ def _resolve_intent_case_meta(item):
             getattr(func, "_intent_case_skill_id", ""))
 
 
-def pytest_configure(config):
-    """Auto-discover ``ovoscope_intent_cases`` declarations in conftest
-    modules so skills don't need to write any Python in their test files.
+def _autodiscover_intent_cases(config):
+    """Walk pytest's loaded test modules and trigger auto-discovery.
 
-    Walks every collected ``conftest`` module looking for a top-level
-    ``ovoscope_intent_cases`` dict; for each one found, generates the
-    full set of intent-case TestCase classes inside that conftest's
-    namespace. Skills already calling
-    :func:`ovoscope.intent_cases.register_intent_case_tests` explicitly
-    are unaffected (the explicit call marks the module as registered).
+    Pytest collects tests from files matching ``test_*.py`` (or
+    ``*_test.py``) — *not* from ``conftest.py``. So the auto-discovery
+    target is a thin shim module like ``test_intent_cases.py`` that
+    declares::
+
+        ovoscope_intent_cases = dict(skill_id=..., handlers=...)
+
+    On the very first ``pytest_pycollect_makemodule`` we resolve the
+    module, scan it for that declaration, and inject the generated
+    TestCase classes into its namespace before pytest collects items
+    from it. The user writes one variable assignment, no
+    ``register_intent_case_tests`` call, no ``globals()`` argument.
+
+    Skills already calling :func:`register_intent_case_tests` explicitly
+    are skipped via the ``_ovoscope_intent_cases_registered`` marker.
     """
-    import sys
+    # Tracked in pytest_pycollect_makemodule; this helper kept for symmetry
+    # / future use (e.g. a CLI hook).
+    return None
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_pycollect_makemodule(module_path, path, parent):
+    """Auto-register intent-case tests on shim modules that declare
+    ``ovoscope_intent_cases = {...}``.
+
+    The hookwrapper imports the module first, lets pytest build the
+    collector, then injects the generated TestCase classes into the
+    module's namespace so the standard Python-class collector finds them.
+    """
     from ovoscope.intent_cases import autodiscover_from_conftest
-    # We can't enumerate conftests directly until collection runs; instead
-    # piggy-back on the already-imported sys.modules. The pytest config
-    # phase runs after rootdir-conftests have imported, so any top-level
-    # `ovoscope_intent_cases = {...}` is already in sys.modules.
-    for mod in list(sys.modules.values()):
-        if mod is None or not hasattr(mod, "__file__"):
-            continue
-        try:
-            if not getattr(mod, "__file__", "").endswith("conftest.py"):
-                continue
-        except (AttributeError, TypeError):
-            continue
-        if getattr(mod, "_ovoscope_intent_cases_registered", False):
-            continue
-        try:
-            autodiscover_from_conftest(
-                Path(mod.__file__).parent,
-                mod.__dict__,
-            )
-        except Exception as exc:  # noqa: BLE001
-            # Non-fatal: a malformed config shouldn't prevent collection;
-            # surface in the logs instead.
-            print(f"ovoscope auto-discovery skipped for {mod.__file__}: "
-                  f"{exc}")
+
+    outcome = yield
+    collector = outcome.get_result()
+    if collector is None:
+        return
+    try:
+        mod = collector.obj  # imports the module if not already loaded
+    except Exception:
+        return
+    if not hasattr(mod, "ovoscope_intent_cases"):
+        return
+    if getattr(mod, "_ovoscope_intent_cases_registered", False):
+        return
+    try:
+        autodiscover_from_conftest(Path(mod.__file__).parent, mod.__dict__)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ovoscope auto-discovery skipped for {mod.__file__}: {exc}")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/test/unittests/test_intent_cases.py
+++ b/test/unittests/test_intent_cases.py
@@ -1,0 +1,142 @@
+# Copyright 2024 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for ovoscope.intent_cases helpers and the accuracy reporter.
+
+Tests focus on the parts that don't need a live MiniCroft: the file-layout
+loader, the JSON summary roll-ups, the structural baseline diff, and the
+Markdown report renderer. The end-to-end execution path is covered by
+the consumer skill's e2e suite.
+"""
+from pathlib import Path
+from unittest import TestCase
+
+from ovoscope.intent_cases import (IntentCase, _read_lines, load_intent_cases)
+from ovoscope.pytest_plugin import (_accuracy_markdown, _accuracy_summary,
+                                     _baseline_diff)
+
+
+class TestLoadIntentCases(TestCase):
+    """Discovery of <lang>/<Intent>.intent.test and no_match.test files."""
+
+    def _write(self, tmp, lang, name, body):
+        d = tmp / "cases" / lang
+        d.mkdir(parents=True, exist_ok=True)
+        (d / name).write_text(body, encoding="utf-8")
+
+    def test_loads_intent_and_no_match_files(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._write(tmp, "en-US", "WhoAreYou.intent.test",
+                        "# header\nwho are you\nwhat is your name\n")
+            self._write(tmp, "en-US", "no_match.test", "what time is it\n")
+            cases = load_intent_cases(tmp / "cases",
+                                      known_intents=["WhoAreYou.intent"])
+            self.assertEqual(len(cases), 3)
+            self.assertEqual(sum(1 for c in cases if c.intent is None), 1)
+            self.assertTrue(all(c.lang == "en-US" for c in cases))
+
+    def test_unknown_intent_raises(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._write(tmp, "en-US", "Mystery.intent.test", "x\n")
+            with self.assertRaises(AssertionError):
+                load_intent_cases(tmp / "cases",
+                                  known_intents=["WhoAreYou.intent"])
+
+    def test_skips_comments_and_blank_lines(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._write(tmp, "en-US", "WhoAreYou.intent.test",
+                        "# a\n\n  \nfoo\n#bar\n")
+            cases = load_intent_cases(tmp / "cases",
+                                      known_intents=["WhoAreYou.intent"])
+            self.assertEqual([c.utterance for c in cases], ["foo"])
+
+
+class TestAccuracySummary(TestCase):
+    """Aggregate roll-ups feeding the markdown / terminal pivots."""
+
+    def _r(self, **kw):
+        base = {"pipeline": "TestX", "lang": "en-US",
+                "intent": "WhoAreYou.intent", "utterance": "u",
+                "passed": True, "source": ""}
+        base.update(kw)
+        return base
+
+    def test_overall_and_pivots(self):
+        results = [
+            self._r(),
+            self._r(passed=False),
+            self._r(pipeline="TestY"),
+        ]
+        s = _accuracy_summary(results)
+        self.assertEqual(s["total"], 3)
+        self.assertEqual(s["passed"], 2)
+        self.assertAlmostEqual(s["overall_accuracy"], 2 / 3)
+        # Per-pipeline bucket exists for both pipelines.
+        self.assertEqual(s["by_pipeline"]["TestX"]["total"], 2)
+        self.assertEqual(s["by_pipeline"]["TestY"]["pass"], 1)
+        # by_utterance carries failing_pipelines for diagnosis.
+        by_utt = {(u["lang"], u["intent"], u["utterance"]): u
+                  for u in s["by_utterance"]}
+        u = by_utt[("en-US", "WhoAreYou.intent", "u")]
+        self.assertIn("TestX", u["failing_pipelines"])
+
+
+class TestBaselineDiff(TestCase):
+    """Structural baseline diff: regressed vs recovered."""
+
+    def _r(self, pipeline, passed, utterance="u"):
+        return {"pipeline": pipeline, "lang": "en-US",
+                "intent": "WhoAreYou.intent", "utterance": utterance,
+                "passed": passed}
+
+    def test_diff_classifies_flips(self):
+        baseline = [self._r("TestX", True), self._r("TestY", False)]
+        current = [self._r("TestX", False), self._r("TestY", True),
+                   self._r("TestZ", True)]
+        d = _baseline_diff(baseline, current)
+        self.assertEqual(len(d["regressed"]), 1)
+        self.assertEqual(d["regressed"][0]["pipeline"], "TestX")
+        self.assertEqual(len(d["recovered"]), 1)
+        self.assertEqual(d["recovered"][0]["pipeline"], "TestY")
+        self.assertEqual(len(d["added"]), 1)
+        self.assertEqual(d["added"][0]["pipeline"], "TestZ")
+        self.assertEqual(d["baseline_total"], 2)
+
+
+class TestAccuracyMarkdown(TestCase):
+    """Markdown report includes every section we need for PR comments."""
+
+    def test_markdown_contains_expected_sections(self):
+        results = [
+            {"pipeline": "TestA", "lang": "en-US", "intent": "I.intent",
+             "utterance": "ok phrase", "passed": True},
+            {"pipeline": "TestA", "lang": "en-US", "intent": "I.intent",
+             "utterance": "bad phrase", "passed": False},
+        ]
+        s = _accuracy_summary(results)
+        md = _accuracy_markdown(s, results)
+        self.assertIn("intent-case checks passed", md)
+        self.assertIn("| Pipeline | Pass / Total | Accuracy |", md)
+        self.assertIn("Per-pipeline × language", md)
+        self.assertIn("Per-pipeline × intent", md)
+        self.assertIn("Hardest utterances", md)
+        # The failing utterance must be quoted in the hardest list.
+        self.assertIn("bad phrase", md)
+
+    def test_baseline_diff_section_when_supplied(self):
+        baseline = [{"pipeline": "TestA", "lang": "en-US",
+                     "intent": "I.intent", "utterance": "phrase",
+                     "passed": True}]
+        current = [{"pipeline": "TestA", "lang": "en-US",
+                    "intent": "I.intent", "utterance": "phrase",
+                    "passed": False}]
+        s = _accuracy_summary(current)
+        d = _baseline_diff(baseline, current)
+        md = _accuracy_markdown(s, current, baseline_diff=d)
+        self.assertIn("Baseline diff", md)
+        self.assertIn("Regressed (1)", md)


### PR DESCRIPTION
Follow-up to #58. Adds the missing pieces needed to actually surface the intent-case accuracy data in a PR review without diving into action logs, and removes the last sleep-based race.

## 1. Markdown report (`--ovoscope-accuracy-md=PATH`)

Renders the per-(pipeline, lang, intent) pivot as Markdown with collapsible `<details>` sections. Drops directly into the gh-automations PR-comment workflow as a new 🎯 **Intent-Case Accuracy** section alongside the existing 🔌 Skill Tests / 🚌 Bus Coverage panels (matching PR: OpenVoiceOS/gh-automations#32).

Includes a **Hardest utterances** table (top-N by cross-pipeline pass rate) so reviewers can immediately see which phrasings need locale tuning. `--ovoscope-accuracy-top-n` controls the cut-off (default 10).

## 2. Structural baseline diff

Replaces the previous scalar `overall_accuracy < baseline` gate with a per-case structural diff:

- **Regressed** — was-pass in baseline, now-fail
- **Recovered** — was-fail in baseline, now-pass
- **Added / Removed** — case lists that changed between runs

The PR comment lists regressed cases verbatim (pipeline / lang / intent / utterance) and the session fails if any regression is present. JSON output now carries a `baseline_diff` block for downstream tooling.

## 3. Auto-discovery via conftest

Skills can opt-in to intent-case tests with **zero Python in their test module**:

```python
# test/end2end/conftest.py
ovoscope_intent_cases = dict(
    skill_id="my-skill.author",
    handlers={"WhoAreYou.intent": "MySkill.handle_who", ...},
)
```

A new pytest_configure walks loaded conftest modules and calls `register_intent_case_tests()` automatically. The explicit API stays supported.

## 4. Deterministic m2v warmup

Replaces the `time.sleep(10)` in `_shared_minicroft` with a bus-event wait: listen for `padatious:register_intent` until quiet for 0.5 s, then pad for the in-plugin 3 s `handle_sync_intents` debounce. Falls back to a sleep on any failure so the suite stays robust to FakeBus internals changing.

## Tests

`test/unittests/test_intent_cases.py` — 7 unit tests covering the case-file loader, the summary roll-ups (incl. new `by_utterance` rollup), the structural baseline diff, and the Markdown emitter (sections, baseline diff section). Runs in <1 s, no MiniCroft required.

## Test plan

- [ ] `pytest test/unittests/test_intent_cases.py` — 7/7 pass
- [ ] Skill consumer (`ovos-skill-personal` PR #103) produces a populated `intent-accuracy.md` locally
- [ ] gh-automations PR (#32) renders the new section in the PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI options `--ovoscope-accuracy-md` and `--ovoscope-accuracy-top-n` for enhanced accuracy reporting.
  * Improved accuracy reporting with Markdown output, baseline comparison, and "hardest utterances" ranking.
  * Added baseline diff detection to identify regressed and recovered cases.
  * Enhanced pytest auto-discovery for intent test cases.

* **Tests**
  * Added comprehensive unit tests for intent case utilities and accuracy reporting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/ovoscope/pull/60)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->