### PR TITLE
fix(pipeline-harness): default _SinkSkill bus to FakeBus

### DIFF
--- a/ovoscope/pipeline.py
+++ b/ovoscope/pipeline.py
@@ -42,11 +42,14 @@ class _SinkSkill:
     return it from :meth:`match`.
     """
 
-    def __init__(self, bus: Any, skill_id: str = "__ovoscope_sink__") -> None:
+    def __init__(self, bus: Optional[Any] = None, skill_id: str = "__ovoscope_sink__") -> None:
+        from ovos_utils.fakebus import FakeBus
+
         self.skill_id = skill_id
         self._last_match: Optional[Message] = None
-        self._bus: Any = None
-        self.bus = bus
+        self._bus: Any = bus if bus is not None else FakeBus()
+        self._bus.on("intent.service.skills.activated", self._handle)
+        self._bus.on("intent_failure", self._handle_failure)
 
     @property
     def bus(self) -> Any:
@@ -54,17 +57,17 @@ class _SinkSkill:
 
     @bus.setter
     def bus(self, new_bus: Any) -> None:
-        # Detach handlers from the previous bus (if any) before rebinding.
-        if self._bus is not None:
-            try:
-                self._bus.remove("intent.service.skills.activated", self._handle)
-                self._bus.remove("intent_failure", self._handle_failure)
-            except Exception:
-                pass
+        if new_bus is None:
+            raise ValueError("_SinkSkill.bus cannot be None; pass a real bus or omit to default to FakeBus.")
+        # Detach handlers from the previous bus before rebinding.
+        try:
+            self._bus.remove("intent.service.skills.activated", self._handle)
+            self._bus.remove("intent_failure", self._handle_failure)
+        except Exception:
+            pass
         self._bus = new_bus
-        if new_bus is not None:
-            new_bus.on("intent.service.skills.activated", self._handle)
-            new_bus.on("intent_failure", self._handle_failure)
+        new_bus.on("intent.service.skills.activated", self._handle)
+        new_bus.on("intent_failure", self._handle_failure)
 
     def _handle(self, message: Any) -> None:
         """Capture matched intent messages."""
@@ -122,8 +125,9 @@ class PipelineHarness:
         """Start MiniCroft with the specified pipeline and no skills."""
         from ovoscope import get_minicroft
 
-        # Inject internal sink skill to capture matched intents
-        sink_skill = _SinkSkill(bus=None)  # bus set after MiniCroft creation
+        # Inject internal sink skill to capture matched intents.
+        # Constructed with a default FakeBus; rebound to MiniCroft's real bus below.
+        sink_skill = _SinkSkill()
 
         self._mc = get_minicroft(
             skill_ids=[],

--- a/ovoscope/pipeline.py
+++ b/ovoscope/pipeline.py
@@ -43,11 +43,28 @@ class _SinkSkill:
     """
 
     def __init__(self, bus: Any, skill_id: str = "__ovoscope_sink__") -> None:
-        self.bus = bus
         self.skill_id = skill_id
         self._last_match: Optional[Message] = None
-        bus.on("intent.service.skills.activated", self._handle)
-        bus.on("intent_failure", self._handle_failure)
+        self._bus: Any = None
+        self.bus = bus
+
+    @property
+    def bus(self) -> Any:
+        return self._bus
+
+    @bus.setter
+    def bus(self, new_bus: Any) -> None:
+        # Detach handlers from the previous bus (if any) before rebinding.
+        if self._bus is not None:
+            try:
+                self._bus.remove("intent.service.skills.activated", self._handle)
+                self._bus.remove("intent_failure", self._handle_failure)
+            except Exception:
+                pass
+        self._bus = new_bus
+        if new_bus is not None:
+            new_bus.on("intent.service.skills.activated", self._handle)
+            new_bus.on("intent_failure", self._handle_failure)
 
     def _handle(self, message: Any) -> None:
         """Capture matched intent messages."""

--- a/test/unittests/test_pipeline_harness.py
+++ b/test/unittests/test_pipeline_harness.py
@@ -2,10 +2,12 @@
 
 import pytest
 
+from ovos_utils.fakebus import FakeBus
+
 from ovoscope.pipeline import _SinkSkill
 
 
-class _FakeBus:
+class _RecordingBus:
     def __init__(self):
         self.handlers = []
         self.removed = []
@@ -18,41 +20,39 @@ class _FakeBus:
 
 
 class TestSinkSkillBusHandling:
-    def test_constructs_with_bus_none(self):
-        # Regression: _SinkSkill(bus=None) used to crash because __init__
-        # called bus.on(...) before checking for None. PipelineHarness relies
-        # on this two-step construction (create skill, then attach bus after
-        # MiniCroft is built).
-        sink = _SinkSkill(bus=None)
-        assert sink.bus is None
+    def test_default_constructs_with_fakebus(self):
+        # Regression: previously _SinkSkill(bus=None) crashed and
+        # PipelineHarness relied on passing None then rebinding. Now bus
+        # defaults to a FakeBus so construction is always safe and the
+        # skill is immediately usable.
+        sink = _SinkSkill()
+        assert isinstance(sink.bus, FakeBus)
         assert sink._last_match is None
 
-    def test_attaches_when_bus_set_via_setter(self):
+    def test_explicit_none_falls_back_to_fakebus(self):
         sink = _SinkSkill(bus=None)
-        bus = _FakeBus()
-        sink.bus = bus
-        # Both subscriptions registered
-        events = [e for e, _ in bus.handlers]
-        assert "intent.service.skills.activated" in events
-        assert "intent_failure" in events
+        assert isinstance(sink.bus, FakeBus)
 
-    def test_constructs_with_live_bus(self):
-        bus = _FakeBus()
+    def test_constructs_with_supplied_bus(self):
+        bus = _RecordingBus()
         sink = _SinkSkill(bus=bus)
         events = [e for e, _ in bus.handlers]
         assert "intent.service.skills.activated" in events
         assert "intent_failure" in events
 
     def test_rebinding_bus_detaches_previous(self):
-        old = _FakeBus()
-        new = _FakeBus()
+        old = _RecordingBus()
+        new = _RecordingBus()
         sink = _SinkSkill(bus=old)
         sink.bus = new
-        # Old bus had its handlers removed
-        old_removed_events = [e for e, _ in old.removed]
-        assert "intent.service.skills.activated" in old_removed_events
-        assert "intent_failure" in old_removed_events
-        # New bus has fresh handlers
+        old_removed = [e for e, _ in old.removed]
+        assert "intent.service.skills.activated" in old_removed
+        assert "intent_failure" in old_removed
         new_events = [e for e, _ in new.handlers]
         assert "intent.service.skills.activated" in new_events
         assert "intent_failure" in new_events
+
+    def test_setting_bus_to_none_raises(self):
+        sink = _SinkSkill()
+        with pytest.raises(ValueError):
+            sink.bus = None

--- a/test/unittests/test_pipeline_harness.py
+++ b/test/unittests/test_pipeline_harness.py
@@ -1,0 +1,58 @@
+"""Regression tests for ovoscope.pipeline._SinkSkill."""
+
+import pytest
+
+from ovoscope.pipeline import _SinkSkill
+
+
+class _FakeBus:
+    def __init__(self):
+        self.handlers = []
+        self.removed = []
+
+    def on(self, event, handler):
+        self.handlers.append((event, handler))
+
+    def remove(self, event, handler):
+        self.removed.append((event, handler))
+
+
+class TestSinkSkillBusHandling:
+    def test_constructs_with_bus_none(self):
+        # Regression: _SinkSkill(bus=None) used to crash because __init__
+        # called bus.on(...) before checking for None. PipelineHarness relies
+        # on this two-step construction (create skill, then attach bus after
+        # MiniCroft is built).
+        sink = _SinkSkill(bus=None)
+        assert sink.bus is None
+        assert sink._last_match is None
+
+    def test_attaches_when_bus_set_via_setter(self):
+        sink = _SinkSkill(bus=None)
+        bus = _FakeBus()
+        sink.bus = bus
+        # Both subscriptions registered
+        events = [e for e, _ in bus.handlers]
+        assert "intent.service.skills.activated" in events
+        assert "intent_failure" in events
+
+    def test_constructs_with_live_bus(self):
+        bus = _FakeBus()
+        sink = _SinkSkill(bus=bus)
+        events = [e for e, _ in bus.handlers]
+        assert "intent.service.skills.activated" in events
+        assert "intent_failure" in events
+
+    def test_rebinding_bus_detaches_previous(self):
+        old = _FakeBus()
+        new = _FakeBus()
+        sink = _SinkSkill(bus=old)
+        sink.bus = new
+        # Old bus had its handlers removed
+        old_removed_events = [e for e, _ in old.removed]
+        assert "intent.service.skills.activated" in old_removed_events
+        assert "intent_failure" in old_removed_events
+        # New bus has fresh handlers
+        new_events = [e for e, _ in new.handlers]
+        assert "intent.service.skills.activated" in new_events
+        assert "intent_failure" in new_events


### PR DESCRIPTION
## Summary

\`PipelineHarness\` is unusable in the current release. The context manager constructs the internal sink skill with \`bus=None\` and assigns the real bus only after MiniCroft is created (\`pipeline.py:109,121\`), but \`_SinkSkill.__init__\` unconditionally calls \`bus.on(...)\` on the None bus, raising:

\`\`\`
AttributeError: 'NoneType' object has no attribute 'on'
\`\`\`

## Fix

\`_SinkSkill\` now always has a real bus:

- \`bus\` argument is optional and defaults to a \`FakeBus()\` — construction is always safe and the skill is immediately usable
- the \`bus\` property setter rebinds cleanly (detaches handlers from the old bus, attaches to the new one) so \`PipelineHarness\` can swap to MiniCroft's bus after construction
- setting \`bus = None\` after construction raises \`ValueError\` — None is never a valid bus state

\`PipelineHarness.__enter__\` drops the special-case \`_SinkSkill(bus=None)\` / late-rebind dance and just calls \`_SinkSkill()\`.

## Tests

\`test/unittests/test_pipeline_harness.py\` covers: default FakeBus construction, explicit \`bus=None\` (also falls back to FakeBus), supplied bus, bus rebind detaches previous, and \`bus = None\` raises.

## Repro before fix

\`\`\`python
from ovoscope.pipeline import PipelineHarness

with PipelineHarness(pipeline=[\"ovos-adapt-pipeline-plugin.openvoiceos\"]) as h:
    h.assert_matches(\"hello\")
# AttributeError: 'NoneType' object has no attribute 'on'
\`\`\`

Discovered while writing pipeline tests for \`linha-fina\` ([TigreGotico/linha-fina#9](https://github.com/TigreGotico/linha-fina/pull/9)).

## Test plan

- [x] \`pytest test/unittests/test_pipeline_harness.py -v\` → 5 passed
- [ ] CI green