### PR TITLE
feat(phal): plugin_factories for MiniPHAL and PHALTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,9 @@ In the interest of transparency, two files are maintained as a public record of 
   significant AI-assisted session.
 These files are intentionally published so that contributors and users can understand how the
 project evolves and where AI assistance has been applied.
+
+## Credits
+
+Funded by [NGI0 Commons Fund](https://nlnet.nl/project/OpenVoiceOS) / [NLnet](https://nlnet.nl)
+under grant agreement No [101135429](https://cordis.europa.eu/project/id/101135429),
+through the European Commission's [Next Generation Internet](https://ngi.eu) programme.

--- a/ovoscope/phal.py
+++ b/ovoscope/phal.py
@@ -34,10 +34,10 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.messagebus import Message
+from ovos_bus_client.message import Message
 
 
 class MiniPHAL:
@@ -50,6 +50,13 @@ class MiniPHAL:
         plugin_ids: OPM entry-point IDs of the PHAL plugins to load.
         plugin_instances: Pre-built or mocked plugin instances keyed by plugin_id.
             When provided the corresponding entry in *plugin_ids* is skipped.
+            Note: instances must have been constructed with the same ``FakeBus``
+            that ``MiniPHAL`` provides — use *plugin_factories* instead when
+            the plugin must be built inside the harness context.
+        plugin_factories: Callables ``(bus: FakeBus) -> plugin`` keyed by
+            plugin_id.  The factory is called during ``__enter__`` so the plugin
+            is always wired to the harness ``FakeBus``.  Takes precedence over
+            *plugin_instances* for the same plugin_id.
         config: Per-plugin configuration overrides keyed by plugin_id.
 
     Example::
@@ -60,16 +67,29 @@ class MiniPHAL:
         ) as phal:
             phal.emit(Message("system.reboot"))
             phal.assert_emitted("system.reboot.confirmed")
+
+    Factory example (plugin must be built with the harness bus)::
+
+        from ovos_phal_plugin_tools import OVOSToolsPHALPlugin
+
+        with MiniPHAL(
+            plugin_ids=["ovos-phal-plugin-tools"],
+            plugin_factories={"ovos-phal-plugin-tools": lambda bus: OVOSToolsPHALPlugin(bus=bus)},
+        ) as phal:
+            phal.emit(Message("ovos.tools.list", {}))
+            phal.assert_emitted("ovos.tools.list.response")
     """
 
     def __init__(
         self,
         plugin_ids: Optional[List[str]] = None,
         plugin_instances: Optional[Dict[str, Any]] = None,
+        plugin_factories: Optional[Dict[str, Callable[[FakeBus], Any]]] = None,
         config: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> None:
         self.plugin_ids: List[str] = plugin_ids or []
         self.plugin_instances: Dict[str, Any] = plugin_instances or {}
+        self.plugin_factories: Dict[str, Callable[[FakeBus], Any]] = plugin_factories or {}
         self.config: Dict[str, Dict[str, Any]] = config or {}
         self._bus: FakeBus = FakeBus()
         self._captured: List[Message] = []
@@ -108,9 +128,19 @@ class MiniPHAL:
         self._captured.append(message)
 
     def _load_plugins(self) -> None:
-        """Load PHAL plugins via OPM or use pre-built instances."""
+        """Load PHAL plugins via factories, pre-built instances, or OPM."""
         for plugin_id in self.plugin_ids:
-            if plugin_id in self.plugin_instances:
+            if plugin_id in self.plugin_factories:
+                try:
+                    instance = self.plugin_factories[plugin_id](self._bus)
+                except Exception as exc:
+                    import warnings
+                    warnings.warn(
+                        f"Factory for PHAL plugin {plugin_id!r} raised: {exc}",
+                        stacklevel=2,
+                    )
+                    instance = None
+            elif plugin_id in self.plugin_instances:
                 instance = self.plugin_instances[plugin_id]
             else:
                 instance = self._instantiate_plugin(plugin_id)
@@ -215,6 +245,8 @@ class PHALTest:
         expected_types: Message types that MUST appear in the capture.
         forbidden_types: Message types that MUST NOT appear.
         plugin_instances: Pre-built plugin instances (keyed by plugin_id).
+        plugin_factories: Callables ``(bus) -> plugin`` keyed by plugin_id.
+            Use this when the plugin must be constructed with the harness bus.
         config: Per-plugin config overrides.
         timeout: Maximum seconds to wait for expected messages (default 5.0).
 
@@ -236,6 +268,7 @@ class PHALTest:
     expected_types: List[str] = field(default_factory=list)
     forbidden_types: List[str] = field(default_factory=list)
     plugin_instances: Dict[str, Any] = field(default_factory=dict)
+    plugin_factories: Dict[str, Callable[[FakeBus], Any]] = field(default_factory=dict)
     config: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     timeout: float = 5.0
 
@@ -251,6 +284,7 @@ class PHALTest:
         with MiniPHAL(
             plugin_ids=self.plugin_ids,
             plugin_instances=self.plugin_instances,
+            plugin_factories=self.plugin_factories,
             config=self.config,
         ) as phal:
             phal.emit(self.trigger_message, wait=0.1)

--- a/test/unittests/test_phal.py
+++ b/test/unittests/test_phal.py
@@ -141,3 +141,97 @@ class TestPHALTest:
         )
         result = t.execute()
         assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# plugin_factories
+# ---------------------------------------------------------------------------
+
+
+class TestPluginFactories:
+    """Tests for the plugin_factories parameter added to MiniPHAL and PHALTest."""
+
+    def _make_responder_factory(self, trigger_type: str, response_type: str):
+        """Return a factory callable that wires a trigger→response handler on the bus."""
+
+        def factory(bus: FakeBus):
+            plugin = MagicMock()
+            plugin.shutdown = MagicMock()
+            bus.on(trigger_type, lambda m: bus.emit(Message(response_type)))
+            return plugin
+
+        return factory
+
+    def test_factory_called_with_harness_bus(self):
+        """Factory receives the MiniPHAL internal bus."""
+        received_buses = []
+
+        def factory(bus: FakeBus):
+            received_buses.append(bus)
+            return MagicMock()
+
+        with MiniPHAL(
+            plugin_ids=["test-plugin"],
+            plugin_factories={"test-plugin": factory},
+        ) as phal:
+            assert len(received_buses) == 1
+            assert received_buses[0] is phal._bus
+
+    def test_factory_plugin_receives_emitted_message(self):
+        """Plugin built by factory can handle messages emitted via phal.emit()."""
+        factory = self._make_responder_factory("req.type", "resp.type")
+        with MiniPHAL(
+            plugin_ids=["echo-plugin"],
+            plugin_factories={"echo-plugin": factory},
+        ) as phal:
+            phal.emit(Message("req.type"), wait=0.1)
+            msg = phal.assert_emitted("resp.type", timeout=2.0)
+            assert msg.msg_type == "resp.type"
+
+    def test_factory_takes_precedence_over_plugin_instances(self):
+        """When both factory and instance are provided, factory wins."""
+        factory_calls = []
+
+        def factory(bus: FakeBus):
+            factory_calls.append(True)
+            return MagicMock()
+
+        stale_instance = MagicMock()
+        with MiniPHAL(
+            plugin_ids=["dual-plugin"],
+            plugin_factories={"dual-plugin": factory},
+            plugin_instances={"dual-plugin": stale_instance},
+        ) as phal:
+            assert len(factory_calls) == 1
+            assert "dual-plugin" in phal._loaded
+            # stale_instance was NOT loaded
+            assert phal._loaded["dual-plugin"] is not stale_instance
+
+    def test_factory_raising_warns_and_skips_plugin(self):
+        """A factory that raises issues a warning and the plugin is not loaded."""
+        import warnings
+
+        def bad_factory(bus: FakeBus):
+            raise RuntimeError("factory error")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with MiniPHAL(
+                plugin_ids=["bad-plugin"],
+                plugin_factories={"bad-plugin": bad_factory},
+            ) as phal:
+                assert "bad-plugin" not in phal._loaded
+        assert any("bad-plugin" in str(warning.message) for warning in w)
+
+    def test_phal_test_plugin_factories_field(self):
+        """PHALTest.plugin_factories is forwarded to MiniPHAL."""
+        factory = self._make_responder_factory("ovos.req", "ovos.resp")
+        t = PHALTest(
+            plugin_ids=["my-phal"],
+            trigger_message=Message("ovos.req"),
+            expected_types=["ovos.resp"],
+            plugin_factories={"my-phal": factory},
+            timeout=2.0,
+        )
+        captured = t.execute()
+        assert any(m.msg_type == "ovos.resp" for m in captured)


### PR DESCRIPTION
Adds plugin_factories support, fixes deprecated Message import, adds 5 factory tests.