### PR TITLE
feat: MiniVoiceLoop + simple/classic listener bus-sequence harnesses

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 | [pydantic-integration.md](pydantic-integration.md) | Using `ovos-pydantic-models` with OvoScope |
 | [audio-testing.md](audio-testing.md) | `AudioServiceHarness`, `PlaybackServiceHarness` — testing audio services |
 | [listener.md](listener.md) | `MiniListener`, `get_mini_listener`, `ListenerTest`, `MockVADEngine`, `MockHotWordEngine`, `VADTest`, `WakeWordTest` — testing audio transformer plugins, STT pipeline, VAD, and wake-word |
+| [voice-loop.md](voice-loop.md) | `MiniVoiceLoop` / `MiniSimpleListener` / `MiniClassicListener` — file-driven bus-sequence testing for the ovos-dinkum, ovos-simple, and mycroft-classic listener services (wake-word → record-begin → utterance), with verifier-chain gating |
 | [gui-testing.md](gui-testing.md) | `GUICaptureSession` — asserting GUI page navigation and namespace values |
 | [bus-coverage.md](bus-coverage.md) | `BusCoverageTracker`, `BusCoverageReport` — measuring handler and emitter coverage per skill |
 ## Conceptual Model
@@ -84,6 +85,17 @@ from ovoscope.listener import (
     VADTest,             # declarative VAD test runner
     WakeWordTest,        # declarative WakeWord test runner
 )
+# Listener-service bus-sequence testing (dinkum / simple / classic)
+from ovoscope import (
+    MiniVoiceLoop,        # ovos-dinkum-listener: feed PCM chunks or an audio file
+    MiniSimpleListener,   # ovos-simple-listener: drive the loop over an audio file
+    MiniClassicListener,  # mycroft-classic-listener: best-effort file drive + bridge
+    get_mini_voice_loop,  # factory: create MiniVoiceLoop
+    VoiceLoopTest,        # declarative wake-word → bus-sequence test runner
+    MiniHotwordContainer, # controllable hotword container with a verifier chain
+    MockFileMicrophone,   # file-backed mic plugin shared across listener harnesses
+    MockStreamingSTT,     # configurable transcript STT mock
+)
 ```
 Type aliases also exported:
 ```python
@@ -115,12 +127,37 @@ msgs = listener.feed_audio(b"\x00" * 1024)
 listener.shutdown()
 ```
 
+## Listener-Service Bus-Sequence Testing
+
+OVOS has several listener **services** — ovos-dinkum-listener, ovos-simple-listener,
+and mycroft-classic-listener — each emitting the same `recognizer_loop:*` bus
+events.  `MiniVoiceLoop`, `MiniSimpleListener`, and `MiniClassicListener` each
+wire their real service to a `FakeBus` with mock mic/VAD/STT/wake-word plugins,
+drive it over an arbitrary audio file (or PCM frames), and capture the emitted
+sequence — sharing one set of assertion helpers.  `MiniVoiceLoop` also exercises
+the dinkum verifier-chain gate that decides whether a detection survives.
+
+See [voice-loop.md](voice-loop.md) for full API reference and usage patterns.
+
+```python
+from unittest.mock import Mock
+from ovoscope.voice_loop import MiniVoiceLoop, MockHotWordEngine
+
+ww = MockHotWordEngine("hey_mycroft", trigger_after=3)
+accepting = Mock(); accepting.verify.return_value = True
+
+with MiniVoiceLoop(ww_instances={"hey_mycroft": ww},
+                   verifiers=[accepting]) as vl:
+    msgs = vl.feed_chunks([b"\x00" * 512] * 5)
+    vl.assert_record_begin_emitted(msgs)
+```
+
 ## What OvoScope Does NOT Do
 - Does not start a real WebSocket MessageBus server — uses `FakeBus` (in-process pub/sub).
 - Does not load PHAL plugins or the audio service — only skills and the intent pipeline.
 - Does not test GUI rendering — GUI namespace messages are ignored by default (`ignore_gui=True`).
 - Does not test TTS — operates at the `recognizer_loop:utterance` level (see [audio-testing.md](audio-testing.md) for TTS lifecycle testing).
-- `MiniListener` covers `AudioTransformersService`, the STT pipeline, and mock VAD/WakeWord engines — not the full `DinkumVoiceLoop` state machine.
+- `MiniListener` covers `AudioTransformersService`, the STT pipeline, and mock VAD/WakeWord engines. `MiniVoiceLoop` / `MiniSimpleListener` / `MiniClassicListener` drive the dinkum, simple, and classic listener **services** from an audio file and capture the `recognizer_loop:*` bus sequence; the classic file drive is best-effort (energy-based pipeline).
 ## Quick Links
 | Resource | Path |
 |---|---|

--- a/docs/voice-loop.md
+++ b/docs/voice-loop.md
@@ -1,0 +1,203 @@
+# Listener Service Bus-Sequence Testing
+
+OVOS ships more than one listener **service**, and each emits the same
+``recognizer_loop:*`` bus events as audio flows through it.  ovoscope provides an
+in-process harness for each, sharing one capture bus and one set of assertion
+helpers (:class:`ovoscope.voice_loop.ListenerHarness`):
+
+| Service | Harness | Drive |
+|---|---|---|
+| ovos-dinkum-listener | `MiniVoiceLoop` | `feed_chunks` (wake-word / verifier gate) + `feed_file` (full `DinkumVoiceLoop.run()`) |
+| ovos-simple-listener | `MiniSimpleListener` | `feed_file` (full `SimpleListener` loop) |
+| mycroft-classic-listener | `MiniClassicListener` | `feed_file` (best-effort) + `bridge_recognizer_loop_to_bus` |
+
+Each harness wires its real listener to a `FakeBus` with mock mic / VAD / STT /
+wake-word plugins, runs it over an arbitrary audio file (or PCM frames), and
+captures the emitted bus sequence.  The mocks live in
+`ovoscope.voice_loop`: `MockFileMicrophone`, `MockStreamingSTT`,
+`MockVADEngine`, `MockHotWordEngine`.
+
+## Shared assertion helpers
+
+Every harness inherits these (each takes an optional message list, defaulting to
+the last feed result, and returns the checked list):
+
+- `assert_record_begin_emitted()` — `recognizer_loop:record_begin` present.
+- `assert_wakeword_detected()` — both `recognizer_loop:wakeword` and `…:record_begin`.
+- `assert_wakeword_suppressed()` — neither wake-word nor record-begin present.
+- `assert_utterance_emitted(utterance=None)` — a `recognizer_loop:utterance` (optionally with the given text).
+
+---
+
+## ovos-dinkum-listener — `MiniVoiceLoop`
+
+### Wake-word / verifier gate (`feed_chunks`)
+
+Feeds PCM frames straight through `DinkumVoiceLoop._detect_ww` to assert the
+wake-word detection and the verifier chain in isolation.
+
+```python
+from unittest.mock import Mock
+from ovoscope.voice_loop import MiniVoiceLoop, MockHotWordEngine
+
+SILENT = b"\x00" * 512
+
+def loop(verifiers):
+    ww = MockHotWordEngine("hey_mycroft", trigger_after=3)
+    return MiniVoiceLoop(ww_instances={"hey_mycroft": ww}, verifiers=verifiers)
+
+acc = Mock(); acc.verify.return_value = True
+with loop([acc]) as vl:
+    vl.assert_wakeword_detected(vl.feed_chunks([SILENT] * 5))
+
+rej = Mock(); rej.verify.return_value = False
+with loop([rej]) as vl:
+    vl.assert_wakeword_suppressed(vl.feed_chunks([SILENT] * 5))
+
+boom = Mock(); boom.verify.side_effect = RuntimeError("boom")
+with loop([boom]) as vl:                       # fail-open
+    vl.assert_record_begin_emitted(vl.feed_chunks([SILENT] * 5))
+```
+
+| Sequence | Expected bus events |
+|---|---|
+| WW detected + all verifiers accept | `recognizer_loop:wakeword` + `…:record_begin` |
+| WW detected + a verifier rejects | suppressed — no `recognizer_loop:*` |
+| WW detected + a verifier raises (fail-open) | `…:record_begin` emitted |
+| No WW detected | no `recognizer_loop:*` |
+
+The verifier gate lives inside `DinkumVoiceLoop._detect_ww` and is only present
+in ovos-dinkum-listener builds that ship the hotword-verifier feature
+(`HotwordContainer.verify`).  On a build without it the gate is absent and a
+detection is never suppressed — assert accordingly for the version under test.
+
+### Full loop from an audio file (`feed_file`)
+
+Runs the whole `DinkumVoiceLoop.run()` state machine over an audio file through a
+`MockFileMicrophone`, emitting the full record-begin → record-end → utterance
+sequence.
+
+```python
+from ovoscope.voice_loop import MiniVoiceLoop, MockStreamingSTT
+
+stt = MockStreamingSTT(transcript="what time is it")
+with MiniVoiceLoop(stt_instance=stt) as vl:
+    msgs = vl.feed_file("command.wav")
+    vl.assert_record_begin_emitted(msgs)
+    vl.assert_utterance_emitted("what time is it", msgs)
+```
+
+An empty `MockStreamingSTT` transcript yields
+`recognizer_loop:speech.recognition.unknown` instead of an utterance.
+
+`MiniVoiceLoop` builds a real `DinkumVoiceLoop`; it raises `RuntimeError` when
+ovos-dinkum-listener is not installed.
+
+---
+
+## ovos-simple-listener — `MiniSimpleListener`
+
+Drives the real `SimpleListener` thread with the canonical bus callbacks (a
+per-instance mirror of `OVOSCallbacks`).
+
+```python
+from ovoscope.simple_listener import MiniSimpleListener
+from ovoscope.voice_loop import MockHotWordEngine, MockStreamingSTT
+
+with MiniSimpleListener(
+    wakeword=MockHotWordEngine("hey_mycroft", trigger_after=2),
+    stt_instance=MockStreamingSTT(transcript="turn on the lights"),
+) as sl:
+    msgs = sl.feed_file("command.wav")
+    sl.assert_record_begin_emitted(msgs)
+    sl.assert_utterance_emitted("turn on the lights", msgs)
+```
+
+The default timing is tightened (`min_speech_seconds=0`,
+`max_silence_seconds=0.1`) so a file-driven command ends promptly; raise them to
+mimic production. Raises `RuntimeError` when ovos-simple-listener is absent.
+
+---
+
+## mycroft-classic-listener — `MiniClassicListener`
+
+The classic listener is a threaded, energy-based pipeline. Two entry points:
+
+### Event bridge (always available)
+
+`bridge_recognizer_loop_to_bus(loop, bus)` forwards a `RecognizerLoop`'s internal
+EventEmitter events onto a `FakeBus`, exactly as the classic listener's
+`service.py` does. Drive the loop with real audio and assert on the bus:
+
+```python
+from ovoscope.classic_listener import bridge_recognizer_loop_to_bus
+from ovos_utils.fakebus import FakeBus
+
+bus = FakeBus()
+bridge_recognizer_loop_to_bus(loop, bus)   # loop = a RecognizerLoop
+```
+
+### Best-effort file drive
+
+Injects a file-backed audio source and mock wake-word / STT into a fresh
+`RecognizerLoop` and runs it to completion:
+
+```python
+from ovoscope.classic_listener import MiniClassicListener
+from ovoscope.voice_loop import MockHotWordEngine, MockStreamingSTT
+
+with MiniClassicListener(
+    wakeword=MockHotWordEngine("hey_mycroft", trigger_after=1),
+    stt_instance=MockStreamingSTT(transcript="hello world"),
+) as cl:
+    msgs = cl.feed_file("command.wav", tail_silence_seconds=3.0)
+    cl.assert_record_begin_emitted(msgs)
+    cl.assert_utterance_emitted("hello world", msgs)
+```
+
+The file drive depends on the energy-based recogniser, so assertions are
+presence-based (a busy pipeline may emit more than one cycle before it is
+stopped). Use `classic_listener_available()` to gate tests on the environment;
+`MiniClassicListener(...)` (built mode) raises `RuntimeError` when the package is
+absent.
+
+---
+
+## Declarative helper — `VoiceLoopTest`
+
+For the dinkum backend, `VoiceLoopTest` runs a scenario and asserts in one call —
+via `feed_chunks` by default, or `feed_file` when `audio_file` is set:
+
+```python
+from unittest.mock import Mock
+from ovoscope.voice_loop import VoiceLoopTest, MockHotWordEngine, MockStreamingSTT
+
+# verifier gate
+accepting = Mock(); accepting.verify.return_value = True
+VoiceLoopTest(
+    ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=3)},
+    verifiers=[accepting],
+    audio_chunks=[b"\x00" * 512] * 5,
+    expect_record_begin=True,
+).execute()
+
+# full loop from a file
+VoiceLoopTest(
+    audio_file="command.wav",
+    stt_instance=MockStreamingSTT(transcript="what time is it"),
+    expect_utterance="what time is it",
+).execute()
+```
+
+## API surface
+
+| Symbol | Description |
+|---|---|
+| `ListenerHarness` | Base: FakeBus capture + assertion helpers + file-mic. |
+| `MiniVoiceLoop` / `get_mini_voice_loop` | ovos-dinkum-listener harness + factory. |
+| `MiniHotwordContainer` | Controllable hotword container with a fail-open verifier chain. |
+| `MiniSimpleListener` / `get_mini_simple_listener` | ovos-simple-listener harness + factory. |
+| `MiniClassicListener` | mycroft-classic-listener harness (best-effort). |
+| `bridge_recognizer_loop_to_bus` / `classic_listener_available` | Classic event-bridge + capability probe. |
+| `MockFileMicrophone`, `MockStreamingSTT`, `MockVADEngine`, `MockHotWordEngine` | Mock plugins shared across backends. |
+| `VoiceLoopTest` | Declarative dinkum scenario runner. |

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -1107,6 +1107,25 @@ except ImportError as e:
     else:
         raise
 
+from ovoscope.voice_loop import (  # noqa: F401
+    ListenerHarness,
+    MiniVoiceLoop,
+    MiniHotwordContainer,
+    MockFileMicrophone,
+    MockStreamingSTT,
+    get_mini_voice_loop,
+    VoiceLoopTest,
+)
+from ovoscope.simple_listener import (  # noqa: F401
+    MiniSimpleListener,
+    get_mini_simple_listener,
+)
+from ovoscope.classic_listener import (  # noqa: F401
+    MiniClassicListener,
+    bridge_recognizer_loop_to_bus,
+    classic_listener_available,
+)
+
 
 @dataclasses.dataclass
 class GUICaptureSession:

--- a/ovoscope/classic_listener.py
+++ b/ovoscope/classic_listener.py
@@ -1,0 +1,393 @@
+# Copyright 2024 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""MiniClassicListener — drive mycroft-classic-listener for bus-sequence testing.
+
+``mycroft-classic-listener`` is an alternative OVOS listener service built around
+a ``RecognizerLoop`` (a ``pyee`` ``EventEmitter``) running an energy-based
+``ResponsiveRecognizer`` across producer/consumer threads.  Its service layer
+bridges the loop's internal events (``recognizer_loop:record_begin``,
+``…:wakeword``, ``…:record_end``, ``…:utterance``,
+``…:speech.recognition.unknown``) onto the OVOS messagebus.
+
+Two pieces are provided:
+
+* :func:`bridge_recognizer_loop_to_bus` — the reusable event→bus bridge (mirrors
+  the classic listener's ``service.py``).  Wire any ``RecognizerLoop`` to a
+  ``FakeBus`` and assert on the captured sequence.
+* :class:`MiniClassicListener` — a best-effort, file-driven harness that injects
+  a :class:`FileAudioSource` and mock wake-word/STT into a ``RecognizerLoop`` and
+  runs it to completion, sharing the assertion helpers of
+  :class:`ovoscope.voice_loop.ListenerHarness`.
+
+The classic pipeline is energy-threshold based; the file drive is best-effort.
+Use :func:`classic_listener_available` to gate tests on the environment.
+
+Example — event bridge::
+
+    from ovoscope.classic_listener import bridge_recognizer_loop_to_bus
+    from ovos_utils.fakebus import FakeBus
+
+    bus = FakeBus()
+    bridge_recognizer_loop_to_bus(loop, bus)  # loop = a RecognizerLoop
+    # ... drive `loop` with real audio; assert on `bus`
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from ovoscope.voice_loop import (
+    ListenerHarness,
+    MockHotWordEngine,
+    MockStreamingSTT,
+    _read_audio,
+)
+
+
+# ---------------------------------------------------------------------------
+# Event → bus bridge (mirrors mycroft_classic_listener/service.py)
+# ---------------------------------------------------------------------------
+
+def bridge_recognizer_loop_to_bus(loop: Any, bus: FakeBus) -> Any:
+    """Forward a ``RecognizerLoop``'s internal events onto a ``FakeBus``.
+
+    Registers handlers on *loop* (any object with an ``on(event, handler)``
+    EventEmitter API) that re-emit the listener events as bus :class:`Message`
+    objects, exactly as the classic listener's service layer does.
+
+    Args:
+        loop: A ``RecognizerLoop`` (or compatible ``EventEmitter``).
+        bus: The :class:`FakeBus` to emit translated messages on.
+
+    Returns:
+        *loop*, for chaining.
+    """
+    ctx = {"client_name": "mycroft_listener", "source": "audio"}
+
+    loop.on(
+        "recognizer_loop:record_begin",
+        lambda *a: bus.emit(Message("recognizer_loop:record_begin", context=ctx)),
+    )
+    loop.on(
+        "recognizer_loop:record_end",
+        lambda *a: bus.emit(Message("recognizer_loop:record_end", context=ctx)),
+    )
+    loop.on(
+        "recognizer_loop:wakeword",
+        lambda event=None, *a: bus.emit(
+            Message("recognizer_loop:wakeword", event or {})
+        ),
+    )
+    loop.on(
+        "recognizer_loop:utterance",
+        lambda event=None, *a: bus.emit(Message(
+            "recognizer_loop:utterance",
+            event or {},
+            {**ctx, "destination": ["skills"]},
+        )),
+    )
+    loop.on(
+        "recognizer_loop:speech.recognition.unknown",
+        lambda *a: bus.emit(
+            Message("recognizer_loop:speech.recognition.unknown", context=ctx)
+        ),
+    )
+    loop.on(
+        "recognizer_loop:awoken",
+        lambda *a: bus.emit(Message("mycroft.awoken", context=ctx)),
+    )
+    return loop
+
+
+# ---------------------------------------------------------------------------
+# File-backed audio source (classic Microphone subclass)
+# ---------------------------------------------------------------------------
+
+class _FileStream:
+    """Minimal stream serving file PCM then silence, frame by frame.
+
+    Mirrors the read contract the classic ``ResponsiveRecognizer`` expects from
+    a microphone stream: ``read(num_frames, of_exc)`` returns
+    ``num_frames * sample_width`` bytes.
+
+    Args:
+        pcm: Raw PCM bytes of the audio.
+        sample_width: Bytes per sample.
+        tail_silence_bytes: Trailing silence appended after the audio.
+    """
+
+    def __init__(self, pcm: bytes, sample_width: int, tail_silence_bytes: int) -> None:
+        self._data: bytes = pcm + (b"\x00" * tail_silence_bytes)
+        self._sample_width: int = sample_width
+        self._pos: int = 0
+
+    def read(self, num_frames: int, of_exc: bool = False) -> bytes:
+        """Return ``num_frames`` of audio, padding with silence past EOF."""
+        nbytes = num_frames * self._sample_width
+        chunk = self._data[self._pos:self._pos + nbytes]
+        self._pos += len(chunk)
+        if len(chunk) < nbytes:
+            chunk = chunk + b"\x00" * (nbytes - len(chunk))
+        return chunk
+
+    def close(self) -> None:
+        """No-op close."""
+
+    def stop_stream(self) -> None:
+        """No-op stop."""
+
+    def is_stopped(self) -> bool:
+        return False
+
+
+def _make_file_audio_source(
+    audio: Union[bytes, str, Path],
+    chunk_size: int,
+    tail_silence_seconds: float,
+) -> Any:
+    """Build a classic ``Microphone`` whose stream reads from *audio*.
+
+    Bypasses ``Microphone.__init__`` (which opens PyAudio and needs a real input
+    device) while still satisfying the ``isinstance(source, Microphone)`` check
+    in ``ResponsiveRecognizer.listen``.
+    """
+    from mycroft_classic_listener.mic import Microphone
+
+    pcm, sr, sw, _ch = _read_audio(audio, 16000, 2, 1)
+
+    class FileAudioSource(Microphone):
+        """File-backed classic microphone (no PyAudio)."""
+
+        def __init__(self) -> None:
+            self.device_index = None
+            self.format = 8  # pyaudio.paInt16
+            self.SAMPLE_WIDTH = sw
+            self.SAMPLE_RATE = sr
+            self.CHUNK = chunk_size
+            self.muted = False
+            self.audio = None
+            self.stream = None
+            self._pcm = pcm
+            self._tail = int(tail_silence_seconds * sr * sw)
+
+        def __enter__(self):
+            self.stream = _FileStream(self._pcm, self.SAMPLE_WIDTH, self._tail)
+            return self
+
+        def __exit__(self, *_):
+            self.stream = None
+
+        def restart(self):
+            self.stream = _FileStream(self._pcm, self.SAMPLE_WIDTH, self._tail)
+
+        def duration_to_bytes(self, sec):
+            return int(sec * self.SAMPLE_RATE * self.SAMPLE_WIDTH)
+
+        def mute(self):
+            self.muted = True
+
+        def unmute(self):
+            self.muted = False
+
+        def is_muted(self):
+            return self.muted
+
+    return FileAudioSource()
+
+
+def _build_recognizer_loop(file_source: Any, wakeword: Any, stt: Any) -> Any:
+    """Build a ``RecognizerLoop`` with mocks injected, bypassing plugin/hardware.
+
+    Subclasses ``RecognizerLoop`` to replace ``_load_config`` (which would open
+    PyAudio and load real wake-word plugins) and ``start_async`` (which would
+    create a real STT) with the injected file source, wake-word engine, and STT.
+    """
+    from mycroft_classic_listener.listener import (
+        AudioConsumer,
+        AudioProducer,
+        RecognizerLoop,
+        RecognizerLoopState,
+        ResponsiveRecognizer,
+    )
+    try:
+        from queue import Queue
+    except ImportError:  # pragma: no cover
+        from Queue import Queue  # type: ignore
+
+    class _InjectedRecognizerLoop(RecognizerLoop):
+        def __init__(self) -> None:
+            super(RecognizerLoop, self).__init__()  # EventEmitter.__init__
+            self._watchdog = lambda: None
+            self.mute_calls = 0
+            self.lang = "en-us"
+            self.config = {}
+            self.microphone = file_source
+            self.wakeword_recognizer = wakeword
+            self.wakeup_recognizer = MockHotWordEngine("wake_up", trigger_after=10**9)
+            self.responsive_recognizer = ResponsiveRecognizer(
+                self.wakeword_recognizer, self._watchdog
+            )
+            self.state = RecognizerLoopState()
+            self._config_hash = None
+
+        def start_async(self) -> None:
+            self.state.running = True
+            self.producer = AudioProducer(
+                self.state, Queue(), self.microphone,
+                self.responsive_recognizer, self, None,
+            )
+            # share one queue between producer and consumer
+            queue = self.producer.queue
+            self.producer.start()
+            self.consumer = AudioConsumer(
+                self.state, queue, self, stt,
+                self.wakeup_recognizer, self.wakeword_recognizer,
+            )
+            self.consumer.start()
+
+        def stop(self) -> None:
+            self.state.running = False
+            try:
+                self.producer.stop()
+                self.producer.join(timeout=2.0)
+                self.consumer.join(timeout=2.0)
+            except Exception:
+                pass
+
+    return _InjectedRecognizerLoop()
+
+
+def classic_listener_available() -> bool:
+    """Return ``True`` if mycroft-classic-listener can be imported here."""
+    import importlib.util
+
+    try:
+        return all(
+            importlib.util.find_spec(mod) is not None
+            for mod in (
+                "mycroft_classic_listener.listener",
+                "mycroft_classic_listener.mic",
+            )
+        )
+    except ModuleNotFoundError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# MiniClassicListener
+# ---------------------------------------------------------------------------
+
+class MiniClassicListener(ListenerHarness):
+    """Best-effort in-process mycroft-classic-listener harness.
+
+    Wires a ``RecognizerLoop`` (built with a file audio source + mock wake-word /
+    STT, or one supplied by the caller) to a ``FakeBus`` via
+    :func:`bridge_recognizer_loop_to_bus`, then drives it over an audio file.
+
+    Args:
+        recognizer_loop: A pre-built ``RecognizerLoop`` (or compatible
+            EventEmitter).  When provided, only the bus bridge is wired and the
+            caller drives the loop; :meth:`feed_file` is unavailable.
+        wakeword: Wake-word engine for the built loop (defaults to a
+            :class:`MockHotWordEngine`).
+        stt_instance: STT engine for the built loop (defaults to
+            :class:`MockStreamingSTT`).
+        bus: Optional :class:`FakeBus` to capture on.
+
+    Raises:
+        RuntimeError: If *recognizer_loop* is ``None`` and
+            mycroft-classic-listener is not importable.
+    """
+
+    def __init__(
+        self,
+        recognizer_loop: Optional[Any] = None,
+        *,
+        wakeword: Optional[Any] = None,
+        stt_instance: Optional[Any] = None,
+        bus: Optional[FakeBus] = None,
+    ) -> None:
+        super().__init__(bus)
+        self._built = recognizer_loop is None
+        self._wakeword = wakeword
+        self._stt = stt_instance
+
+        if recognizer_loop is not None:
+            self.loop: Any = recognizer_loop
+            bridge_recognizer_loop_to_bus(self.loop, self.bus)
+        else:
+            if not classic_listener_available():
+                raise RuntimeError(
+                    "mycroft-classic-listener is required to build a "
+                    "MiniClassicListener. Install it with: "
+                    "pip install mycroft-classic-listener"
+                )
+            self.loop = None  # built per-run in feed_file (needs the audio)
+
+    def feed_file(
+        self,
+        audio: Union[bytes, str, Path],
+        *,
+        tail_silence_seconds: float = 2.0,
+        chunk_size: int = 1024,
+        timeout: float = 15.0,
+    ) -> List[Message]:
+        """Run the classic loop over an audio file and capture bus events.
+
+        Builds a fresh ``RecognizerLoop`` with a :class:`FileAudioSource`, bridges
+        it to the bus, runs it until a command finishes
+        (``recognizer_loop:record_end``) or *timeout* elapses, then stops it.
+
+        Args:
+            audio: Path to a ``.wav`` file, WAV bytes, or raw PCM bytes.
+            tail_silence_seconds: Trailing silence appended after the audio so
+                the energy recogniser can end the command.
+            chunk_size: Frames per microphone read.
+            timeout: Maximum seconds to wait for the command to finish.
+
+        Returns:
+            The list of :class:`Message` objects emitted during the run.
+
+        Raises:
+            RuntimeError: If this harness was constructed with an external loop.
+        """
+        if not self._built:
+            raise RuntimeError(
+                "feed_file is only available when MiniClassicListener builds the "
+                "RecognizerLoop. Drive the supplied loop yourself and assert on "
+                ".bus instead."
+            )
+
+        wakeword = self._wakeword or MockHotWordEngine("hey_mycroft", trigger_after=1)
+        stt = self._stt or MockStreamingSTT()
+        source = _make_file_audio_source(audio, chunk_size, tail_silence_seconds)
+
+        self.loop = _build_recognizer_loop(source, wakeword, stt)
+        bridge_recognizer_loop_to_bus(self.loop, self.bus)
+
+        self._messages.clear()
+        self.loop.start_async()
+        try:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if self._has(self._messages, "recognizer_loop:record_end"):
+                    break
+                time.sleep(0.02)
+        finally:
+            self.loop.stop()
+
+        self._last_messages = list(self._messages)
+        return list(self._messages)
+
+    def shutdown(self) -> None:
+        """Stop the loop if the harness owns it."""
+        if self._built and self.loop is not None:
+            try:
+                self.loop.stop()
+            except Exception:
+                pass

--- a/ovoscope/simple_listener.py
+++ b/ovoscope/simple_listener.py
@@ -1,0 +1,223 @@
+# Copyright 2024 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""MiniSimpleListener — drive ovos-simple-listener for bus-sequence testing.
+
+``ovos-simple-listener`` is an alternative OVOS listener service: a single
+``SimpleListener`` thread that reads microphone chunks, detects a wake word (or
+VAD activation), records the command, and dispatches a small set of callbacks.
+Its canonical bus integration (``OVOSCallbacks`` in
+``ovos_simple_listener.__main__``) emits ``recognizer_loop:wakeword`` /
+``…:record_begin`` on activation, ``…:utterance`` /
+``…:speech.recognition.unknown`` after STT, and ``…:record_end`` when the command
+finishes.
+
+:class:`MiniSimpleListener` wires a ``SimpleListener`` to a ``FakeBus`` with mock
+wake-word / VAD / STT plugins and a :class:`MockFileMicrophone`, runs the loop
+over an arbitrary audio file, and captures the emitted bus sequence — sharing the
+assertion helpers of :class:`ovoscope.voice_loop.ListenerHarness`.
+
+Example::
+
+    from ovoscope.simple_listener import MiniSimpleListener
+    from ovoscope.voice_loop import MockHotWordEngine, MockStreamingSTT
+
+    with MiniSimpleListener(
+        wakeword=MockHotWordEngine("hey_mycroft", trigger_after=2),
+        stt_instance=MockStreamingSTT(transcript="turn on the lights"),
+    ) as sl:
+        msgs = sl.feed_file("command.wav")
+        sl.assert_record_begin_emitted(msgs)
+        sl.assert_utterance_emitted("turn on the lights", msgs)
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from ovoscope.voice_loop import (
+    ListenerHarness,
+    MockHotWordEngine,
+    MockStreamingSTT,
+    MockVADEngine,
+)
+
+
+class _SimpleBusCallbacks:
+    """Per-instance ``ListenerCallbacks`` that emit on a ``FakeBus``.
+
+    Mirrors the canonical ``OVOSCallbacks`` from
+    ``ovos_simple_listener.__main__`` (minus the listen-sound playback), but
+    binds the bus per instance instead of on the class so concurrent harnesses
+    do not clobber one another.
+
+    Args:
+        bus: The :class:`FakeBus` to emit listener events on.
+    """
+
+    def __init__(self, bus: FakeBus) -> None:
+        self.bus: FakeBus = bus
+
+    def listen_callback(self) -> None:
+        """Activation: emit wakeword + record-begin."""
+        self.bus.emit(Message("recognizer_loop:wakeword"))
+        self.bus.emit(Message("recognizer_loop:record_begin"))
+
+    def end_listen_callback(self) -> None:
+        """Command finished: emit record-end."""
+        self.bus.emit(Message("recognizer_loop:record_end"))
+
+    def audio_callback(self, audio: Any) -> None:
+        """Recorded command audio is available (no-op)."""
+
+    def error_callback(self, audio: Any) -> None:
+        """Empty transcription: emit the recognition-unknown event."""
+        self.bus.emit(Message("recognizer_loop:speech.recognition.unknown"))
+
+    def text_callback(self, utterance: str, lang: str) -> None:
+        """Transcription succeeded: emit the utterance."""
+        self.bus.emit(Message(
+            "recognizer_loop:utterance",
+            {"utterances": [utterance], "lang": lang},
+        ))
+
+
+class MiniSimpleListener(ListenerHarness):
+    """In-process ovos-simple-listener harness for bus-sequence testing.
+
+    Args:
+        wakeword: Wake-word engine (``update`` + ``found_wake_word``).  Defaults
+            to a :class:`MockHotWordEngine` keyed ``"hey_mycroft"``.  Pass
+            ``None`` to use VAD-only activation.
+        vad_instance: VAD engine (defaults to :class:`MockVADEngine`).
+        stt_instance: Streaming STT engine (defaults to
+            :class:`MockStreamingSTT` returning no transcript).
+        min_speech_seconds: Minimum command speech before a silence can end it.
+        max_silence_seconds: Trailing silence that ends a command.
+        max_speech_seconds: Hard cap on command length.
+        bus: Optional :class:`FakeBus` to capture on.
+
+    Raises:
+        RuntimeError: If ovos-simple-listener is not installed.
+
+    The default timing is tightened (``min_speech_seconds=0`` /
+    ``max_silence_seconds=0.1``) so a file-driven command ends promptly and
+    deterministically; raise them to mimic production behaviour.
+    """
+
+    def __init__(
+        self,
+        *,
+        wakeword: Optional[Any] = "__default__",
+        vad_instance: Optional[Any] = None,
+        stt_instance: Optional[Any] = None,
+        min_speech_seconds: float = 0.0,
+        max_silence_seconds: float = 0.1,
+        max_speech_seconds: float = 8.0,
+        bus: Optional[FakeBus] = None,
+    ) -> None:
+        super().__init__(bus)
+
+        try:
+            from ovos_simple_listener import SimpleListener
+        except ImportError as e:
+            raise RuntimeError(
+                "ovos-simple-listener is required to use MiniSimpleListener. "
+                "Install it with: pip install ovos-simple-listener"
+            ) from e
+
+        if wakeword == "__default__":
+            wakeword = MockHotWordEngine("hey_mycroft", trigger_after=2)
+
+        self.callbacks = _SimpleBusCallbacks(self.bus)
+        self.listener = SimpleListener(
+            wakeword=wakeword,
+            mic=None,  # supplied per-run by feed_file
+            vad=vad_instance if vad_instance is not None else MockVADEngine(),
+            stt=stt_instance if stt_instance is not None else MockStreamingSTT(),
+            min_speech_seconds=min_speech_seconds,
+            max_silence_seconds=max_silence_seconds,
+            max_speech_seconds=max_speech_seconds,
+            callbacks=self.callbacks,
+        )
+
+    def feed_file(
+        self,
+        audio: Union[bytes, str, Path],
+        *,
+        silence_tail_chunks: int = 25,
+        chunk_size: int = 2048,
+        timeout: float = 10.0,
+    ) -> List[Message]:
+        """Run the simple listener over an audio file and capture bus events.
+
+        Streams *audio* through a :class:`MockFileMicrophone`, runs the listener
+        thread until the command completes (``recognizer_loop:record_end``) or
+        *timeout* elapses, then stops it.
+
+        Args:
+            audio: Path to a ``.wav`` file, WAV bytes, or raw PCM bytes.
+            silence_tail_chunks: Trailing silent frames appended after the audio
+                so the command can end.
+            chunk_size: Bytes per microphone read.
+            timeout: Maximum seconds to wait for the command to finish.
+
+        Returns:
+            The list of :class:`Message` objects emitted during the run.
+        """
+        mic = self._build_file_mic(audio, silence_tail_chunks, chunk_size)
+        self.listener.mic = mic
+
+        self._messages.clear()
+        self.listener.start()  # Thread.start → runs the loop in the background
+        try:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if self._has(self._messages, "recognizer_loop:record_end"):
+                    break
+                time.sleep(0.02)
+        finally:
+            self.listener.stop()
+            self.listener.join(timeout=2.0)
+
+        self._last_messages = list(self._messages)
+        return list(self._messages)
+
+    def shutdown(self) -> None:
+        """Stop the listener thread if still running."""
+        try:
+            self.listener.stop()
+            if self.listener.is_alive():
+                self.listener.join(timeout=2.0)
+        except Exception:
+            pass
+
+
+def get_mini_simple_listener(
+    wakeword: Optional[Any] = "__default__",
+    vad_instance: Optional[Any] = None,
+    stt_instance: Optional[Any] = None,
+    bus: Optional[FakeBus] = None,
+) -> MiniSimpleListener:
+    """Factory: create a ready-to-feed :class:`MiniSimpleListener`.
+
+    Args:
+        wakeword: Wake-word engine (defaults to a :class:`MockHotWordEngine`).
+        vad_instance: VAD engine (defaults to :class:`MockVADEngine`).
+        stt_instance: Streaming STT engine (defaults to
+            :class:`MockStreamingSTT`).
+        bus: Optional :class:`FakeBus` to capture on.
+
+    Returns:
+        A fully initialised :class:`MiniSimpleListener`.
+    """
+    return MiniSimpleListener(
+        wakeword=wakeword,
+        vad_instance=vad_instance,
+        stt_instance=stt_instance,
+        bus=bus,
+    )

--- a/ovoscope/voice_loop.py
+++ b/ovoscope/voice_loop.py
@@ -1,0 +1,1056 @@
+# Copyright 2024 OpenVoiceOS
+# Licensed under the Apache License, Version 2.0
+"""MiniVoiceLoop — drive ``DinkumVoiceLoop`` bus sequences for ovoscope.
+
+Where :class:`ovoscope.listener.MiniListener` covers the
+``AudioTransformersService``, STT, and mock VAD/WakeWord engines, it does **not**
+exercise the full ``DinkumVoiceLoop`` state machine.  The bus events that matter
+for wake-word handling (``recognizer_loop:wakeword``,
+``recognizer_loop:record_begin``, ``recognizer_loop:record_end``,
+``recognizer_loop:utterance``) are emitted as side-effects of the voice loop as
+PCM chunks flow through it.
+
+``MiniVoiceLoop`` wires a real ``DinkumVoiceLoop`` to a ``FakeBus`` with no-op
+mic/STT/transformer plugins, a controllable hotword container, and an optional
+verifier chain.  It supports two drive modes:
+
+* :meth:`MiniVoiceLoop.feed_chunks` — feed PCM frames directly through
+  ``_detect_ww`` to assert the wake-word detection / verifier gate in isolation.
+* :meth:`MiniVoiceLoop.feed_file` — run the **whole** ``DinkumVoiceLoop.run()``
+  state machine, reading an arbitrary audio file through a file-backed
+  microphone plugin, so the full record-begin → wakeword → command → record-end
+  → utterance sequence is captured.
+
+Example — verifier gate (``_detect_ww`` only)::
+
+    from unittest.mock import Mock
+    from ovoscope.voice_loop import MiniVoiceLoop, MockHotWordEngine
+
+    SILENT_CHUNK = b"\\x00" * 512
+    ww = MockHotWordEngine(key_phrase="hey_mycroft", trigger_after=3)
+    accepting = Mock(); accepting.verify.return_value = True
+
+    with MiniVoiceLoop(ww_instances={"hey_mycroft": ww},
+                       verifiers=[accepting]) as vl:
+        msgs = vl.feed_chunks([SILENT_CHUNK] * 5)
+        vl.assert_record_begin_emitted(msgs)
+
+Example — full loop driven from an audio file::
+
+    from ovoscope.voice_loop import MiniVoiceLoop, MockStreamingSTT
+
+    stt = MockStreamingSTT(transcript="what time is it")
+    with MiniVoiceLoop(stt_instance=stt) as vl:
+        msgs = vl.feed_file("command.wav")
+        assert any(m.msg_type == "recognizer_loop:utterance" for m in msgs)
+
+The verifier gate lives inside ``DinkumVoiceLoop._detect_ww`` and is only present
+in ovos-dinkum-listener builds that ship the hotword-verifier feature
+(``HotwordContainer.verify``).  On a build without it the gate is absent and the
+detection is never suppressed — assert accordingly for the version under test.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+# Re-export the engine mocks so callers have a single import site for the
+# voice-loop harness.
+from ovoscope.listener import MockHotWordEngine, MockVADEngine  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _read_audio(
+    audio: Union[bytes, str, Path],
+    sample_rate: int,
+    sample_width: int,
+    sample_channels: int,
+) -> Tuple[bytes, int, int, int]:
+    """Read raw PCM from a WAV file/bytes (or raw PCM) for the file mic.
+
+    Args:
+        audio: Path to a ``.wav`` file, WAV bytes, or raw PCM bytes.
+        sample_rate: Fallback sample rate when no WAV header is present.
+        sample_width: Fallback sample width (bytes).
+        sample_channels: Fallback channel count.
+
+    Returns:
+        ``(pcm_bytes, sample_rate, sample_width, sample_channels)``.
+    """
+    if isinstance(audio, (str, Path)):
+        with open(audio, "rb") as fh:
+            raw = fh.read()
+    else:
+        raw = audio
+
+    try:
+        with wave.open(io.BytesIO(raw)) as wf:
+            sample_rate = wf.getframerate()
+            sample_width = wf.getsampwidth()
+            sample_channels = wf.getnchannels()
+            pcm = wf.readframes(wf.getnframes())
+            return pcm, sample_rate, sample_width, sample_channels
+    except (wave.Error, EOFError):
+        # not a WAV container — treat input as raw PCM
+        return raw, sample_rate, sample_width, sample_channels
+
+
+# ---------------------------------------------------------------------------
+# Mock plugin stand-ins for the DinkumVoiceLoop dependencies
+# ---------------------------------------------------------------------------
+
+class _MockMicrophone:
+    """Silent stand-in for the listener ``Microphone`` plugin.
+
+    Used when no audio file is driven; ``_detect_ww`` does not read from the
+    mic, but the dataclass requires one and a few derived values
+    (``sample_rate``, ``seconds_per_chunk``) are referenced by adjacent loop
+    stages.
+
+    Args:
+        sample_rate: Audio sample rate in Hz.
+        sample_width: Sample width in bytes.
+        sample_channels: Channel count.
+        chunk_size: Bytes per read.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        sample_width: int = 2,
+        sample_channels: int = 1,
+        chunk_size: int = 2048,
+    ) -> None:
+        self.sample_rate: int = sample_rate
+        self.sample_width: int = sample_width
+        self.sample_channels: int = sample_channels
+        self.chunk_size: int = chunk_size
+
+    @property
+    def seconds_per_chunk(self) -> float:
+        """Duration in seconds of one ``chunk_size`` read."""
+        frames = self.chunk_size / max(self.sample_width, 1)
+        return frames / max(self.sample_rate, 1)
+
+    def read_chunk(self) -> bytes:
+        """Return a silent chunk (the harness feeds audio explicitly)."""
+        return b"\x00" * self.chunk_size
+
+    def start(self) -> None:
+        """No-op start hook."""
+
+    def stop(self) -> None:
+        """No-op stop hook."""
+
+
+class MockFileMicrophone:
+    """File-backed ``Microphone`` plugin for the voice loop.
+
+    Streams an arbitrary audio file (or raw PCM) into ``DinkumVoiceLoop.run()``
+    one ``chunk_size`` frame at a time, then appends a tail of silent frames so
+    a silence-based VAD can detect the end of the command.  When every frame has
+    been read, :meth:`read_chunk` invokes :attr:`on_exhausted` (used by
+    :class:`MiniVoiceLoop` to stop the loop) and returns ``None``.
+
+    Args:
+        audio: Path to a ``.wav`` file, WAV bytes, or raw PCM bytes.
+        chunk_size: Bytes per :meth:`read_chunk`.
+        sample_rate: Fallback sample rate when the input has no WAV header.
+        sample_width: Fallback sample width (bytes).
+        sample_channels: Fallback channel count.
+        silence_chunks: Number of trailing silent frames appended after the
+            file so the command can end and the loop can return to wake-word
+            detection.
+
+    Attributes:
+        on_exhausted: Optional zero-arg callback invoked once the audio is fully
+            consumed (set by :class:`MiniVoiceLoop` to stop the loop).
+    """
+
+    def __init__(
+        self,
+        audio: Union[bytes, str, Path],
+        chunk_size: int = 2048,
+        sample_rate: int = 16000,
+        sample_width: int = 2,
+        sample_channels: int = 1,
+        silence_chunks: int = 25,
+    ) -> None:
+        pcm, sr, sw, ch = _read_audio(
+            audio, sample_rate, sample_width, sample_channels
+        )
+        self.sample_rate: int = sr
+        self.sample_width: int = sw
+        self.sample_channels: int = ch
+        self.chunk_size: int = chunk_size
+
+        self._chunks: List[bytes] = [
+            pcm[i:i + chunk_size] for i in range(0, len(pcm), chunk_size)
+        ]
+        self._chunks.extend(b"\x00" * chunk_size for _ in range(silence_chunks))
+        self._idx: int = 0
+        self.on_exhausted: Optional[Any] = None
+
+    @property
+    def seconds_per_chunk(self) -> float:
+        """Duration in seconds of one ``chunk_size`` read."""
+        frames = self.chunk_size / max(self.sample_width, 1)
+        return frames / max(self.sample_rate, 1)
+
+    def read_chunk(self) -> Optional[bytes]:
+        """Return the next audio frame, or ``None`` when exhausted.
+
+        On exhaustion the :attr:`on_exhausted` callback is invoked so the loop
+        can stop.
+        """
+        if self._idx >= len(self._chunks):
+            if self.on_exhausted is not None:
+                self.on_exhausted()
+            return None
+        chunk = self._chunks[self._idx]
+        self._idx += 1
+        return chunk
+
+    def start(self) -> None:
+        """No-op start hook."""
+
+    def stop(self) -> None:
+        """No-op stop hook."""
+
+
+class MockStreamingSTT:
+    """Configurable streaming STT engine for the voice loop.
+
+    Returns a fixed transcript when the recorded command is finalized.  An empty
+    transcript yields ``recognizer_loop:speech.recognition.unknown`` (matching
+    the real listener), which is useful for asserting the silent-recording path.
+
+    Args:
+        transcript: Text returned by :meth:`transcribe`.  Empty string means "no
+            transcription".
+        confidence: Confidence score paired with the transcript.
+        lang: Language tag reported by the ``lang`` property.
+    """
+
+    can_stream: bool = False
+
+    def __init__(
+        self,
+        transcript: str = "",
+        confidence: float = 1.0,
+        lang: str = "en-us",
+    ) -> None:
+        self.transcript: str = transcript
+        self.confidence: float = confidence
+        self._lang: str = lang
+        self.fed_chunks: int = 0
+
+    @property
+    def lang(self) -> str:
+        """Language tag for transcription."""
+        return self._lang
+
+    def stream_start(self, *args: Any, **kwargs: Any) -> None:
+        """Begin a streaming transcription session (no-op)."""
+
+    def stream_data(self, chunk: bytes) -> None:
+        """Feed audio to the streaming session."""
+        self.fed_chunks += 1
+
+    def stream_stop(self) -> str:
+        """End the session and return the transcript text."""
+        return self.transcript
+
+    def execute(self, audio: Any = None, language: Optional[str] = None) -> Optional[str]:
+        """Non-streaming transcription (used by mycroft-classic-listener).
+
+        Args:
+            audio: Recorded audio clip (ignored).
+            language: Language override (ignored).
+
+        Returns:
+            The configured transcript, or ``None`` when empty (so the classic
+            consumer emits ``recognizer_loop:speech.recognition.unknown``).
+        """
+        return self.transcript or None
+
+    def transcribe(
+        self, audio: Any = None, lang: Optional[str] = None
+    ) -> List[Tuple[str, float]]:
+        """Return the configured transcript as ``[(text, confidence)]``.
+
+        Always returns a single ``(text, confidence)`` pair — the text is the
+        empty string when no transcript is configured.  This matches the
+        ``transcribe(audio)[0][0]`` access pattern used by ovos-simple-listener
+        while still letting the dinkum loop's confidence filter run; harness
+        callbacks treat an empty transcript as "no utterance".
+
+        Args:
+            audio: Ignored (the loop streams audio via :meth:`stream_data`).
+            lang: Ignored language override.
+
+        Returns:
+            ``[(transcript, confidence)]``.
+        """
+        return [(self.transcript, self.confidence)]
+
+    def shutdown(self) -> None:
+        """Graceful shutdown (no-op)."""
+
+
+class _MockTransformers:
+    """No-op ``AudioTransformersService`` stand-in.
+
+    Args:
+        bus: The :class:`FakeBus` the loop is wired to.
+    """
+
+    def __init__(self, bus: FakeBus) -> None:
+        self.bus: FakeBus = bus
+        self.hotword_chunks: List[bytes] = []
+
+    def feed_hotword(self, chunk: bytes) -> None:
+        """Record a chunk forwarded after wake-word detection."""
+        self.hotword_chunks.append(chunk)
+
+    def feed_audio(self, chunk: bytes) -> None:
+        """Consume a non-speech chunk (no-op)."""
+
+    def feed_speech(self, chunk: bytes) -> None:
+        """Consume a speech chunk (no-op)."""
+
+    def transform(self, chunk: bytes) -> Tuple[bytes, Dict[str, Any]]:
+        """Return the chunk unchanged with empty context."""
+        return chunk, {}
+
+    def shutdown(self) -> None:
+        """Graceful shutdown (no-op)."""
+
+
+class MiniHotwordContainer:
+    """Controllable hotword container for :class:`MiniVoiceLoop`.
+
+    Implements the subset of ``ovos_dinkum_listener.voice_loop.HotwordContainer``
+    that the voice loop relies on, without requiring the wrapped engines to be
+    real ``HotWordEngine`` subclasses — so ovoscope's :class:`MockHotWordEngine`
+    can drive the loop directly.
+
+    Every registered engine is treated as a **listen word** (it triggers the STT
+    stage).  :meth:`update` and :meth:`found` are state-aware so the loop's
+    separate hotword-detection branch (``_detect_hot``) does not double-count or
+    mis-fire the listen engines.
+
+    The :meth:`verify` chain mirrors the real container's **fail-open**
+    semantics: a verifier that returns ``False`` suppresses the detection; a
+    verifier that raises is skipped (the detection survives).
+
+    Args:
+        ww_instances: Mapping of wake-word name → engine instance (each engine
+            implements ``update(chunk)``, ``found_wake_word() -> bool`` and
+            ``reset()``).
+        verifiers: Optional list of verifier objects with a
+            ``verify(ww_audio: bytes) -> bool`` method.
+
+    Attributes:
+        state: Listening state, assigned by the voice loop during detection.
+        reload_on_failure: Always ``False`` (no engine reloading in tests).
+    """
+
+    def __init__(
+        self,
+        ww_instances: Dict[str, Any],
+        verifiers: Optional[List[Any]] = None,
+    ) -> None:
+        self._engines: Dict[str, Any] = dict(ww_instances)
+        self.verifiers: List[Any] = list(verifiers) if verifiers else []
+        self.state: Any = None
+        self.reload_on_failure: bool = False
+
+    def _active_engines(self) -> Dict[str, Any]:
+        """Return the engines relevant to the current listening state.
+
+        All registered engines are listen words, so they are active in the
+        ``LISTEN`` state (and when no state has been set yet, as used by direct
+        ``_detect_ww`` feeding).  In every other state — ``HOTWORD``,
+        ``WAKEUP``, ``RECORDING`` — no engines are active.
+        """
+        name = getattr(self.state, "name", None)
+        if name in (None, "LISTEN"):
+            return self._engines
+        return {}
+
+    def update(self, chunk: bytes) -> None:
+        """Feed *chunk* to the engines active in the current state.
+
+        Args:
+            chunk: Raw PCM audio bytes.
+        """
+        for engine in self._active_engines().values():
+            engine.update(chunk)
+
+    def found(self) -> Optional[str]:
+        """Return the name of the first active engine reporting a detection.
+
+        A detected engine is reset so a stale ``update_count`` does not re-fire
+        the wake word on subsequent chunks (e.g. during the silence tail of a
+        file-driven run).
+
+        Returns:
+            The wake-word name, or ``None`` if no active engine fired.
+        """
+        for name, engine in self._active_engines().items():
+            if engine.found_wake_word():
+                engine.reset()
+                return name
+        return None
+
+    def get_ww(self, ww: str) -> Dict[str, Any]:
+        """Return metadata for wake word *ww*.
+
+        Mirrors the keys ``DinkumVoiceLoop`` and the listener's hotword callback
+        read.  The wake word is treated as a listen word (it triggers the STT
+        stage), with no confirmation sound.
+
+        Args:
+            ww: Wake-word name.
+
+        Returns:
+            Metadata dict for the wake word.
+
+        Raises:
+            ValueError: If *ww* is not registered.
+        """
+        if ww not in self._engines:
+            raise ValueError(f"Requested ww not defined: {ww}")
+        engine = self._engines[ww]
+        return {
+            "key_phrase": ww,
+            "module": getattr(engine, "key_phrase", ww),
+            "engine": engine.__class__.__name__,
+            "sound": None,
+            "listen": True,
+            "utterance": None,
+            "stt_lang": "en-us",
+            "bus_event": None,
+            "wakeup": False,
+            "stopword": False,
+        }
+
+    def verify(self, ww_audio: bytes) -> bool:
+        """Run the verifier chain against the wake-word audio.
+
+        Fail-open: only an explicit ``False`` return suppresses the detection;
+        a verifier that raises is skipped.
+
+        Args:
+            ww_audio: Raw PCM bytes of the audio that triggered the engine.
+
+        Returns:
+            ``True`` if every verifier accepts (or none are configured),
+            ``False`` if any verifier rejects the audio.
+        """
+        for verifier in self.verifiers:
+            try:
+                if not verifier.verify(ww_audio):
+                    return False
+            except Exception:
+                # fail-open: a raising verifier does not discard the detection
+                pass
+        return True
+
+    def reset(self) -> None:
+        """Reset all wrapped engines (called by the loop after a command)."""
+        for engine in self._engines.values():
+            try:
+                engine.reset()
+            except Exception:
+                pass
+
+    def shutdown(self) -> None:
+        """Shut down all wrapped engines gracefully."""
+        for engine in self._engines.values():
+            try:
+                engine.shutdown()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Shared harness base
+# ---------------------------------------------------------------------------
+
+class ListenerHarness:
+    """Base for in-process listener-service harnesses.
+
+    Owns a :class:`FakeBus`, captures every ``Message`` emitted on it, and
+    provides the common ``recognizer_loop:*`` assertion helpers.  Concrete
+    backends (:class:`MiniVoiceLoop` for ovos-dinkum-listener,
+    ``MiniSimpleListener`` for ovos-simple-listener, ``MiniClassicListener`` for
+    mycroft-classic-listener) wire their specific listener to this bus and add a
+    drive method (``feed_file`` / ``feed_chunks``).
+
+    Args:
+        bus: Optional :class:`FakeBus` to capture on.  Defaults to a fresh bus.
+    """
+
+    def __init__(self, bus: Optional[FakeBus] = None) -> None:
+        self.bus: FakeBus = bus if bus is not None else FakeBus()
+        self._messages: List[Message] = []
+        self._last_messages: List[Message] = []
+        self.bus.on("message", self._capture)
+
+    def _capture(self, msg: Any) -> None:
+        if isinstance(msg, str):
+            try:
+                msg = Message.deserialize(msg)
+            except Exception:
+                return
+        self._messages.append(msg)
+
+    # ------------------------------------------------------------------
+    # File microphone
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_file_mic(
+        audio: Union[bytes, str, Path],
+        silence_chunks: int,
+        chunk_size: int,
+    ) -> MockFileMicrophone:
+        """Build a :class:`MockFileMicrophone` for *audio*."""
+        return MockFileMicrophone(
+            audio, chunk_size=chunk_size, silence_chunks=silence_chunks
+        )
+
+    # ------------------------------------------------------------------
+    # Assertion helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _has(messages: List[Message], msg_type: str) -> bool:
+        return any(m.msg_type == msg_type for m in messages)
+
+    def _resolve(self, messages: Optional[List[Message]]) -> List[Message]:
+        return messages if messages is not None else self._last_messages
+
+    def assert_record_begin_emitted(
+        self, messages: Optional[List[Message]] = None
+    ) -> List[Message]:
+        """Assert ``recognizer_loop:record_begin`` was emitted.
+
+        Args:
+            messages: Messages to check; defaults to the last feed result.
+
+        Returns:
+            The checked message list.
+
+        Raises:
+            AssertionError: If no record-begin event is present.
+        """
+        msgs = self._resolve(messages)
+        assert self._has(msgs, "recognizer_loop:record_begin"), (
+            "Expected 'recognizer_loop:record_begin' but it was not emitted. "
+            f"Captured: {[m.msg_type for m in msgs]}"
+        )
+        return msgs
+
+    def assert_wakeword_detected(
+        self, messages: Optional[List[Message]] = None
+    ) -> List[Message]:
+        """Assert a wake word was detected and recording began.
+
+        Checks for both ``recognizer_loop:wakeword`` and
+        ``recognizer_loop:record_begin``.
+
+        Args:
+            messages: Messages to check; defaults to the last feed result.
+
+        Returns:
+            The checked message list.
+
+        Raises:
+            AssertionError: If either expected event is missing.
+        """
+        msgs = self._resolve(messages)
+        captured = [m.msg_type for m in msgs]
+        assert self._has(msgs, "recognizer_loop:wakeword"), (
+            "Expected 'recognizer_loop:wakeword' but it was not emitted. "
+            f"Captured: {captured}"
+        )
+        assert self._has(msgs, "recognizer_loop:record_begin"), (
+            "Expected 'recognizer_loop:record_begin' but it was not emitted. "
+            f"Captured: {captured}"
+        )
+        return msgs
+
+    def assert_wakeword_suppressed(
+        self, messages: Optional[List[Message]] = None
+    ) -> List[Message]:
+        """Assert no wake-word recording was triggered.
+
+        Verifies that neither ``recognizer_loop:wakeword`` nor
+        ``recognizer_loop:record_begin`` was emitted.
+
+        Args:
+            messages: Messages to check; defaults to the last feed result.
+
+        Returns:
+            The checked message list.
+
+        Raises:
+            AssertionError: If a wake-word or record-begin event is present.
+        """
+        msgs = self._resolve(messages)
+        captured = [m.msg_type for m in msgs]
+        assert not self._has(msgs, "recognizer_loop:record_begin"), (
+            "Expected wake word to be suppressed, but "
+            f"'recognizer_loop:record_begin' was emitted. Captured: {captured}"
+        )
+        assert not self._has(msgs, "recognizer_loop:wakeword"), (
+            "Expected wake word to be suppressed, but "
+            f"'recognizer_loop:wakeword' was emitted. Captured: {captured}"
+        )
+        return msgs
+
+    def assert_utterance_emitted(
+        self,
+        utterance: Optional[str] = None,
+        messages: Optional[List[Message]] = None,
+    ) -> List[Message]:
+        """Assert a ``recognizer_loop:utterance`` was emitted.
+
+        Args:
+            utterance: When given, also assert this exact text is among the
+                emitted utterances.
+            messages: Messages to check; defaults to the last feed result.
+
+        Returns:
+            The checked message list.
+
+        Raises:
+            AssertionError: If no utterance (or the named one) was emitted.
+        """
+        msgs = self._resolve(messages)
+        utts: List[str] = []
+        for m in msgs:
+            if m.msg_type == "recognizer_loop:utterance":
+                utts.extend(m.data.get("utterances", []))
+        assert utts, (
+            "Expected 'recognizer_loop:utterance' but it was not emitted. "
+            f"Captured: {[m.msg_type for m in msgs]}"
+        )
+        if utterance is not None:
+            assert utterance in utts, (
+                f"Expected utterance {utterance!r} but got: {utts}"
+            )
+        return msgs
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def shutdown(self) -> None:
+        """Release backend resources (overridden by subclasses)."""
+
+    def __enter__(self) -> "ListenerHarness":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# MiniVoiceLoop
+# ---------------------------------------------------------------------------
+
+class MiniVoiceLoop(ListenerHarness):
+    """In-process ``DinkumVoiceLoop`` harness for bus-sequence testing.
+
+    Captures every ``Message`` emitted on the ``FakeBus`` as audio flows through
+    the loop.  The voice-loop callbacks are wired to emit the same bus events as
+    the real listener service (``recognizer_loop:wakeword``,
+    ``recognizer_loop:record_begin``, ``recognizer_loop:record_end``,
+    ``recognizer_loop:utterance`` / ``…:speech.recognition.unknown``).
+
+    Args:
+        voice_loop: A pre-built ``DinkumVoiceLoop`` instance.  When provided, the
+            caller owns its plugins/callbacks, which should emit on this
+            harness's *bus* to be captured.  When ``None``, a loop is built from
+            the mock arguments below.
+        ww_instances: Mapping of wake-word name → engine instance.  Defaults to a
+            single :class:`MockHotWordEngine` keyed ``"hey_mycroft"``.
+        verifiers: Optional verifier objects (``verify(audio) -> bool``) gating
+            detection.
+        vad_instance: Optional VAD engine (defaults to :class:`MockVADEngine`).
+        stt_instance: Optional streaming STT engine (defaults to a
+            :class:`MockStreamingSTT` returning no transcript).  Used by
+            :meth:`feed_file`.
+        bus: Optional :class:`FakeBus` to capture on.  Defaults to a fresh bus.
+
+    Raises:
+        RuntimeError: If *voice_loop* is ``None`` and ovos-dinkum-listener is not
+            installed.
+
+    Example::
+
+        from ovoscope.voice_loop import MiniVoiceLoop, MockHotWordEngine
+
+        ww = MockHotWordEngine("hey_mycroft", trigger_after=3)
+        with MiniVoiceLoop(ww_instances={"hey_mycroft": ww}) as vl:
+            msgs = vl.feed_chunks([b"\\x00" * 512] * 5)
+            vl.assert_record_begin_emitted(msgs)
+    """
+
+    def __init__(
+        self,
+        voice_loop: Optional[Any] = None,
+        *,
+        ww_instances: Optional[Dict[str, Any]] = None,
+        verifiers: Optional[List[Any]] = None,
+        vad_instance: Optional[Any] = None,
+        stt_instance: Optional[Any] = None,
+        bus: Optional[FakeBus] = None,
+    ) -> None:
+        super().__init__(bus)
+
+        self.hotwords: Optional[MiniHotwordContainer] = None
+        if voice_loop is not None:
+            self.voice_loop: Any = voice_loop
+            hw = getattr(voice_loop, "hotwords", None)
+            if isinstance(hw, MiniHotwordContainer):
+                self.hotwords = hw
+        else:
+            self.voice_loop = self._build_voice_loop(
+                ww_instances=ww_instances,
+                verifiers=verifiers,
+                vad_instance=vad_instance,
+                stt_instance=stt_instance,
+            )
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _build_voice_loop(
+        self,
+        ww_instances: Optional[Dict[str, Any]],
+        verifiers: Optional[List[Any]],
+        vad_instance: Optional[Any],
+        stt_instance: Optional[Any],
+    ) -> Any:
+        """Build a ``DinkumVoiceLoop`` wired to this harness's bus.
+
+        Returns:
+            A ready-to-feed ``DinkumVoiceLoop`` instance.
+
+        Raises:
+            RuntimeError: If ovos-dinkum-listener is not installed.
+        """
+        try:
+            from ovos_dinkum_listener.voice_loop.voice_loop import DinkumVoiceLoop
+        except ImportError as e:
+            raise RuntimeError(
+                "ovos-dinkum-listener is required to build a MiniVoiceLoop. "
+                "Install it with: pip install ovos-dinkum-listener"
+            ) from e
+
+        if ww_instances is None:
+            ww_instances = {"hey_mycroft": MockHotWordEngine("hey_mycroft")}
+
+        self.hotwords = MiniHotwordContainer(ww_instances, verifiers=verifiers)
+
+        return DinkumVoiceLoop(
+            mic=_MockMicrophone(),
+            hotwords=self.hotwords,
+            stt=stt_instance if stt_instance is not None else MockStreamingSTT(),
+            fallback_stt=None,
+            vad=vad_instance if vad_instance is not None else MockVADEngine(),
+            transformers=_MockTransformers(self.bus),
+            wake_callback=self._emit_record_begin,
+            record_end_callback=self._emit_record_end,
+            text_callback=self._emit_stt_text,
+            listenword_audio_callback=self._emit_wakeword,
+            hotword_audio_callback=self._emit_wakeword,
+        )
+
+    # ------------------------------------------------------------------
+    # Bus-emitting callbacks (mirror ovos-dinkum-listener service.py)
+    # ------------------------------------------------------------------
+
+    def _emit_record_begin(self) -> None:
+        """Emit ``recognizer_loop:record_begin`` (the real wake callback)."""
+        self.bus.emit(Message("recognizer_loop:record_begin"))
+
+    def _emit_record_end(self) -> None:
+        """Emit ``recognizer_loop:record_end`` (the real record-end callback)."""
+        self.bus.emit(Message("recognizer_loop:record_end"))
+
+    def _emit_wakeword(self, audio_bytes: bytes, ww_context: Dict[str, Any]) -> None:
+        """Emit ``recognizer_loop:wakeword`` for a detected listen word.
+
+        Mirrors the listen-word branch of the listener's ``_hotword_audio``
+        callback so the captured bus sequence matches the real service.
+
+        Args:
+            audio_bytes: Raw hotword audio collected by the loop.
+            ww_context: Wake-word metadata from :meth:`MiniHotwordContainer.get_ww`.
+        """
+        payload = dict(ww_context)
+        key_phrase = ww_context.get("key_phrase", "")
+        payload["utterance"] = key_phrase.replace("_", " ").replace("-", " ")
+        context = {
+            "client_name": "ovos_dinkum_listener",
+            "source": "audio",
+            "destination": ["skills"],
+        }
+        self.bus.emit(Message("recognizer_loop:wakeword", payload, context))
+
+    def _emit_stt_text(
+        self, transcripts: List[Tuple[str, float]], stt_context: Dict[str, Any]
+    ) -> None:
+        """Emit the STT result (mirrors the listener's ``_stt_text`` callback).
+
+        Emits ``recognizer_loop:utterance`` for a non-empty transcript, or
+        ``recognizer_loop:speech.recognition.unknown`` when transcription is
+        empty.
+
+        Args:
+            transcripts: List of ``(text, confidence)`` from the STT engine.
+            stt_context: Context dict accumulated by the loop.
+        """
+        utts = [t[0] for t in transcripts if t[0]] if transcripts else []
+        if utts:
+            lang = stt_context.get("lang") or "en-us"
+            self.bus.emit(Message(
+                "recognizer_loop:utterance",
+                {"utterances": utts, "lang": lang},
+                stt_context,
+            ))
+        else:
+            self.bus.emit(Message(
+                "recognizer_loop:speech.recognition.unknown",
+                context=stt_context,
+            ))
+
+    # ------------------------------------------------------------------
+    # Feeding
+    # ------------------------------------------------------------------
+
+    def feed_chunks(self, chunks: List[bytes]) -> List[Message]:
+        """Feed PCM *chunks* through the voice loop's wake-word detection.
+
+        Each chunk is passed to ``DinkumVoiceLoop._detect_ww``; all bus messages
+        emitted as side-effects are collected and returned.  This drives only
+        the wake-word / verifier stage — use :meth:`feed_file` to run the full
+        state machine.
+
+        Args:
+            chunks: Ordered list of raw PCM audio frames.
+
+        Returns:
+            The list of :class:`Message` objects emitted during this call.
+        """
+        self._messages.clear()
+        for chunk in chunks:
+            self.voice_loop._detect_ww(chunk)
+        self._last_messages = list(self._messages)
+        return list(self._messages)
+
+    def feed_file(
+        self,
+        audio: Union[bytes, str, Path],
+        *,
+        silence_tail_chunks: int = 25,
+        chunk_size: int = 2048,
+    ) -> List[Message]:
+        """Run the full ``DinkumVoiceLoop`` state machine over an audio file.
+
+        Swaps in a :class:`MockFileMicrophone` that streams *audio* through the
+        loop, drives ``start()`` + ``run()`` to completion, and returns every
+        bus message emitted along the way.  A tail of silent frames is appended
+        so a silence-based VAD can end the command and the loop can finalize the
+        utterance.
+
+        Args:
+            audio: Path to a ``.wav`` file, WAV bytes, or raw PCM bytes.
+            silence_tail_chunks: Trailing silent frames appended after the audio
+                (gives the VAD a chance to detect end-of-command).
+            chunk_size: Bytes per microphone read.
+
+        Returns:
+            The list of :class:`Message` objects emitted during the run.
+        """
+        mic = MockFileMicrophone(
+            audio,
+            chunk_size=chunk_size,
+            silence_chunks=silence_tail_chunks,
+        )
+        mic.on_exhausted = self.voice_loop.stop
+        self.voice_loop.mic = mic
+
+        self._messages.clear()
+        self.voice_loop.start()
+        self.voice_loop.run()
+        self._last_messages = list(self._messages)
+        return list(self._messages)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def shutdown(self) -> None:
+        """Shut down the hotword container and wrapped engines."""
+        if self.hotwords is not None:
+            self.hotwords.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def get_mini_voice_loop(
+    ww_instances: Optional[Dict[str, Any]] = None,
+    verifiers: Optional[List[Any]] = None,
+    vad_instance: Optional[Any] = None,
+    stt_instance: Optional[Any] = None,
+    bus: Optional[FakeBus] = None,
+) -> MiniVoiceLoop:
+    """Factory: create a ready-to-feed :class:`MiniVoiceLoop`.
+
+    Args:
+        ww_instances: Mapping of wake-word name → engine instance.  Defaults to a
+            single :class:`MockHotWordEngine` keyed ``"hey_mycroft"``.
+        verifiers: Optional verifier objects gating detection.
+        vad_instance: Optional VAD engine (defaults to :class:`MockVADEngine`).
+        stt_instance: Optional streaming STT engine (defaults to
+            :class:`MockStreamingSTT`).
+        bus: Optional :class:`FakeBus` to capture on.
+
+    Returns:
+        A fully initialised :class:`MiniVoiceLoop`.
+
+    Example::
+
+        from ovoscope.voice_loop import get_mini_voice_loop, MockHotWordEngine
+
+        vl = get_mini_voice_loop(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=3)},
+        )
+        try:
+            vl.assert_record_begin_emitted(vl.feed_chunks([b"\\x00" * 512] * 3))
+        finally:
+            vl.shutdown()
+    """
+    return MiniVoiceLoop(
+        ww_instances=ww_instances,
+        verifiers=verifiers,
+        vad_instance=vad_instance,
+        stt_instance=stt_instance,
+        bus=bus,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Declarative test helper
+# ---------------------------------------------------------------------------
+
+@dataclass
+class VoiceLoopTest:
+    """Declarative wake-word → bus-sequence test for the voice loop.
+
+    Drives a :class:`MiniVoiceLoop` and asserts whether the wake-word recording
+    sequence was triggered.  Feeds PCM frames via ``feed_chunks`` by default, or
+    an audio file via ``feed_file`` when *audio_file* is set.
+
+    Example — verifier gate::
+
+        from unittest.mock import Mock
+        from ovoscope.voice_loop import VoiceLoopTest, MockHotWordEngine
+
+        accepting = Mock(); accepting.verify.return_value = True
+        VoiceLoopTest(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=3)},
+            verifiers=[accepting],
+            audio_chunks=[b"\\x00" * 512] * 5,
+            expect_record_begin=True,
+        ).execute()
+
+    Example — full loop from a file::
+
+        from ovoscope.voice_loop import VoiceLoopTest, MockStreamingSTT
+
+        VoiceLoopTest(
+            audio_file="command.wav",
+            stt_instance=MockStreamingSTT(transcript="what time is it"),
+            expect_utterance="what time is it",
+        ).execute()
+    """
+
+    ww_instances: Optional[Dict[str, Any]] = None
+    """Mapping of wake-word name → engine instance."""
+
+    verifiers: Optional[List[Any]] = None
+    """Verifier objects (``verify(audio) -> bool``) gating detection."""
+
+    vad_instance: Optional[Any] = None
+    """Optional VAD engine (defaults to :class:`MockVADEngine`)."""
+
+    stt_instance: Optional[Any] = None
+    """Optional streaming STT engine (defaults to :class:`MockStreamingSTT`)."""
+
+    audio_chunks: List[bytes] = field(
+        default_factory=lambda: [b"\x00" * 512] * 5
+    )
+    """PCM frames fed via ``feed_chunks`` (ignored when *audio_file* is set)."""
+
+    audio_file: Optional[Union[bytes, str, Path]] = None
+    """When set, run the full loop over this audio via ``feed_file``."""
+
+    expect_record_begin: bool = True
+    """Assert ``recognizer_loop:record_begin`` was emitted (``True``) or
+    suppressed (``False``)."""
+
+    expect_utterance: Optional[str] = None
+    """When set, assert this utterance text was emitted (implies full-loop)."""
+
+    def execute(self) -> List[Message]:
+        """Run the test and assert the configured expectations.
+
+        Returns:
+            The captured :class:`Message` list.
+
+        Raises:
+            AssertionError: If an expectation is not met.
+        """
+        vl = MiniVoiceLoop(
+            ww_instances=self.ww_instances,
+            verifiers=self.verifiers,
+            vad_instance=self.vad_instance,
+            stt_instance=self.stt_instance,
+        )
+        try:
+            if self.audio_file is not None:
+                messages = vl.feed_file(self.audio_file)
+            else:
+                messages = vl.feed_chunks(self.audio_chunks)
+
+            if self.expect_record_begin:
+                vl.assert_record_begin_emitted(messages)
+            else:
+                vl.assert_wakeword_suppressed(messages)
+
+            if self.expect_utterance is not None:
+                vl.assert_utterance_emitted(self.expect_utterance, messages)
+            return messages
+        finally:
+            vl.shutdown()

--- a/test/unittests/test_classic_listener.py
+++ b/test/unittests/test_classic_listener.py
@@ -1,0 +1,110 @@
+# Copyright 2024 Jarbas AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the MiniClassicListener harness (mycroft-classic-listener).
+
+The event-bridge test does not need the classic listener installed (it drives a
+plain EventEmitter).  The file-drive test exercises the real RecognizerLoop and
+is gated on the package being importable.
+"""
+import io
+import unittest
+import wave
+
+from ovos_utils.fakebus import FakeBus
+
+from ovoscope.classic_listener import (
+    MiniClassicListener,
+    bridge_recognizer_loop_to_bus,
+    classic_listener_available,
+)
+from ovoscope.voice_loop import MockHotWordEngine, MockStreamingSTT
+
+try:
+    from pyee import EventEmitter
+    HAS_PYEE = True
+except ImportError:
+    HAS_PYEE = False
+
+HAS_CLASSIC = classic_listener_available()
+
+
+def _wav(speech_seconds=2.0, sample_rate=16000, sample_width=2):
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setframerate(sample_rate)
+        w.setsampwidth(sample_width)
+        w.setnchannels(1)
+        w.writeframes(b"\x10\x20" * int(sample_rate * speech_seconds))
+    return buf.getvalue()
+
+
+@unittest.skipUnless(HAS_PYEE, "pyee not installed")
+class TestEventBridge(unittest.TestCase):
+    """The RecognizerLoop event → FakeBus bridge (no classic listener needed)."""
+
+    def test_bridge_translates_events(self):
+        """Internal loop events become recognizer_loop:* bus messages."""
+        loop = EventEmitter()
+        harness = MiniClassicListener(recognizer_loop=loop)
+
+        loop.emit("recognizer_loop:record_begin")
+        loop.emit("recognizer_loop:wakeword", {"utterance": "hey mycroft"})
+        loop.emit("recognizer_loop:utterance",
+                  {"utterances": ["hello world"], "lang": "en-us"})
+        loop.emit("recognizer_loop:record_end")
+        harness._last_messages = list(harness._messages)
+
+        harness.assert_record_begin_emitted()
+        harness.assert_wakeword_detected()
+        harness.assert_utterance_emitted("hello world")
+
+    def test_bridge_unknown_event(self):
+        """The unknown event is forwarded to the bus."""
+        bus = FakeBus()
+        seen = []
+        bus.on("message", lambda m: seen.append(
+            m if isinstance(m, str) else m.serialize()))
+        loop = EventEmitter()
+        bridge_recognizer_loop_to_bus(loop, bus)
+        loop.emit("recognizer_loop:speech.recognition.unknown")
+        self.assertTrue(
+            any("speech.recognition.unknown" in s for s in seen)
+        )
+
+    def test_feed_file_requires_built_loop(self):
+        """feed_file is unavailable when an external loop was supplied."""
+        harness = MiniClassicListener(recognizer_loop=EventEmitter())
+        with self.assertRaises(RuntimeError):
+            harness.feed_file(b"\x00" * 1024)
+
+
+@unittest.skipUnless(HAS_CLASSIC, "mycroft-classic-listener not installed")
+class TestMiniClassicListenerFileDrive(unittest.TestCase):
+    """Best-effort file-driven test against a real RecognizerLoop."""
+
+    def test_full_sequence_with_utterance(self):
+        """Driving an audio file yields record-begin and the utterance."""
+        with MiniClassicListener(
+            wakeword=MockHotWordEngine("hey_mycroft", trigger_after=1),
+            stt_instance=MockStreamingSTT(transcript="hello world"),
+        ) as cl:
+            msgs = cl.feed_file(_wav(2.0), tail_silence_seconds=3.0, timeout=20)
+            types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:record_begin", types)
+            self.assertIn("recognizer_loop:record_end", types)
+            cl.assert_utterance_emitted("hello world", msgs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_simple_listener.py
+++ b/test/unittests/test_simple_listener.py
@@ -1,0 +1,78 @@
+# Copyright 2024 Jarbas AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the MiniSimpleListener harness (ovos-simple-listener)."""
+import io
+import unittest
+import wave
+
+from ovoscope.simple_listener import MiniSimpleListener
+from ovoscope.voice_loop import MockHotWordEngine, MockStreamingSTT
+
+try:
+    import ovos_simple_listener  # noqa: F401
+    HAS_SIMPLE = True
+except ImportError:
+    HAS_SIMPLE = False
+
+
+def _wav(speech_seconds=0.6, sample_rate=16000, sample_width=2):
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setframerate(sample_rate)
+        w.setsampwidth(sample_width)
+        w.setnchannels(1)
+        w.writeframes(b"\x10\x20" * int(sample_rate * speech_seconds))
+    return buf.getvalue()
+
+
+@unittest.skipUnless(HAS_SIMPLE, "ovos-simple-listener not installed")
+class TestMiniSimpleListener(unittest.TestCase):
+    """MiniSimpleListener integration tests against a real SimpleListener."""
+
+    def test_full_sequence_with_utterance(self):
+        """A wake word + command yields the full bus sequence + utterance."""
+        with MiniSimpleListener(
+            wakeword=MockHotWordEngine("hey_mycroft", trigger_after=2),
+            stt_instance=MockStreamingSTT(transcript="turn on the lights"),
+        ) as sl:
+            msgs = sl.feed_file(_wav(), silence_tail_chunks=20)
+            types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:wakeword", types)
+            self.assertIn("recognizer_loop:record_begin", types)
+            self.assertIn("recognizer_loop:record_end", types)
+            sl.assert_utterance_emitted("turn on the lights", msgs)
+
+    def test_empty_transcript_unknown(self):
+        """An empty transcript emits the recognition-unknown event."""
+        with MiniSimpleListener(
+            wakeword=MockHotWordEngine("hey_mycroft", trigger_after=2),
+            stt_instance=MockStreamingSTT(transcript=""),
+        ) as sl:
+            msgs = sl.feed_file(_wav(), silence_tail_chunks=20)
+            types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:speech.recognition.unknown", types)
+            self.assertNotIn("recognizer_loop:utterance", types)
+
+    def test_record_begin_helper(self):
+        """The shared assert_record_begin_emitted helper works here too."""
+        with MiniSimpleListener(
+            wakeword=MockHotWordEngine("hey_mycroft", trigger_after=1),
+            stt_instance=MockStreamingSTT(transcript="hello"),
+        ) as sl:
+            sl.feed_file(_wav(), silence_tail_chunks=20)
+            sl.assert_record_begin_emitted()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_voice_loop.py
+++ b/test/unittests/test_voice_loop.py
@@ -1,0 +1,302 @@
+# Copyright 2024 Jarbas AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the MiniVoiceLoop harness.
+
+TestMiniHotwordContainer  — container update/found/get_ww/verify (no dinkum)
+TestMiniVoiceLoop         — feed_chunks + helpers (needs ovos-dinkum-listener)
+TestVerifierGate          — verifier suppression (needs the hotword-verifier gate)
+TestVoiceLoopTest         — declarative helper
+"""
+import inspect
+import io
+import unittest
+import wave
+from unittest.mock import Mock
+
+from ovoscope.voice_loop import (
+    MiniHotwordContainer,
+    MiniVoiceLoop,
+    MockHotWordEngine,
+    MockStreamingSTT,
+    VoiceLoopTest,
+    get_mini_voice_loop,
+)
+
+_SILENCE = b"\x00" * 512
+
+
+def _wav(speech_seconds=0.6, sample_rate=16000, sample_width=2):
+    """Build in-memory WAV bytes of non-zero 'speech'."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setframerate(sample_rate)
+        w.setsampwidth(sample_width)
+        w.setnchannels(1)
+        w.writeframes(b"\x10\x20" * int(sample_rate * speech_seconds))
+    return buf.getvalue()
+
+# ovos-dinkum-listener is an optional test dependency — the harness can build a
+# real DinkumVoiceLoop only when it is installed.
+try:
+    from ovos_dinkum_listener.voice_loop.voice_loop import DinkumVoiceLoop
+    HAS_DINKUM = True
+    # The verifier gate is only present in builds shipping the hotword-verifier
+    # feature; suppression assertions require it.
+    HAS_VERIFY_GATE = "self.hotwords.verify" in inspect.getsource(
+        DinkumVoiceLoop._detect_ww
+    )
+except ImportError:
+    HAS_DINKUM = False
+    HAS_VERIFY_GATE = False
+
+
+def _accepting():
+    v = Mock()
+    v.verify.return_value = True
+    return v
+
+
+def _rejecting():
+    v = Mock()
+    v.verify.return_value = False
+    return v
+
+
+def _raising():
+    v = Mock()
+    v.verify.side_effect = RuntimeError("verifier boom")
+    return v
+
+
+# ---------------------------------------------------------------------------
+# MiniHotwordContainer (no dinkum required)
+# ---------------------------------------------------------------------------
+
+class TestMiniHotwordContainer(unittest.TestCase):
+    """MiniHotwordContainer unit tests."""
+
+    def test_found_after_threshold(self):
+        """found() returns the ww name once the engine fires."""
+        c = MiniHotwordContainer(
+            {"hey_mycroft": MockHotWordEngine(trigger_after=2)}
+        )
+        c.update(_SILENCE)
+        self.assertIsNone(c.found())
+        c.update(_SILENCE)
+        self.assertEqual(c.found(), "hey_mycroft")
+
+    def test_found_none_when_not_triggered(self):
+        """found() returns None before the threshold."""
+        c = MiniHotwordContainer(
+            {"hey_mycroft": MockHotWordEngine(trigger_after=10)}
+        )
+        c.update(_SILENCE)
+        self.assertIsNone(c.found())
+
+    def test_update_feeds_all_engines(self):
+        """update() forwards chunks to every registered engine."""
+        a = MockHotWordEngine("hey_mycroft", trigger_after=1)
+        b = MockHotWordEngine("hey_jarbas", trigger_after=1)
+        c = MiniHotwordContainer({"hey_mycroft": a, "hey_jarbas": b})
+        c.update(_SILENCE)
+        self.assertEqual(a.update_count, 1)
+        self.assertEqual(b.update_count, 1)
+
+    def test_get_ww_metadata(self):
+        """get_ww() returns listen-word metadata for a known ww."""
+        c = MiniHotwordContainer({"hey_mycroft": MockHotWordEngine()})
+        meta = c.get_ww("hey_mycroft")
+        self.assertEqual(meta["key_phrase"], "hey_mycroft")
+        self.assertTrue(meta["listen"])
+        self.assertIsNone(meta["sound"])
+
+    def test_get_ww_unknown_raises(self):
+        """get_ww() raises ValueError for an unregistered ww."""
+        c = MiniHotwordContainer({"hey_mycroft": MockHotWordEngine()})
+        with self.assertRaises(ValueError):
+            c.get_ww("unknown")
+
+    def test_verify_accept(self):
+        """verify() returns True when all verifiers accept."""
+        c = MiniHotwordContainer({}, verifiers=[_accepting(), _accepting()])
+        self.assertTrue(c.verify(b"audio"))
+
+    def test_verify_reject(self):
+        """verify() returns False when any verifier rejects."""
+        c = MiniHotwordContainer({}, verifiers=[_accepting(), _rejecting()])
+        self.assertFalse(c.verify(b"audio"))
+
+    def test_verify_fail_open(self):
+        """verify() ignores a raising verifier (fail-open)."""
+        c = MiniHotwordContainer({}, verifiers=[_raising(), _accepting()])
+        self.assertTrue(c.verify(b"audio"))
+
+    def test_verify_no_verifiers(self):
+        """verify() returns True when no verifiers are configured."""
+        c = MiniHotwordContainer({})
+        self.assertTrue(c.verify(b"audio"))
+
+
+# ---------------------------------------------------------------------------
+# MiniVoiceLoop (requires ovos-dinkum-listener)
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(HAS_DINKUM, "ovos-dinkum-listener not installed")
+class TestMiniVoiceLoop(unittest.TestCase):
+    """MiniVoiceLoop integration tests against a real DinkumVoiceLoop."""
+
+    def _loop(self, trigger_after=3, verifiers=None):
+        ww = MockHotWordEngine("hey_mycroft", trigger_after=trigger_after)
+        return MiniVoiceLoop(
+            ww_instances={"hey_mycroft": ww}, verifiers=verifiers
+        )
+
+    def test_accept_emits_record_begin(self):
+        """WW detected + accepting verifier emits the record-begin sequence."""
+        with self._loop(verifiers=[_accepting()]) as vl:
+            msgs = vl.feed_chunks([_SILENCE] * 5)
+            types = {m.msg_type for m in msgs}
+            self.assertIn("recognizer_loop:wakeword", types)
+            self.assertIn("recognizer_loop:record_begin", types)
+
+    def test_no_wakeword_no_events(self):
+        """No detection emits no recognizer_loop events."""
+        with self._loop(trigger_after=100, verifiers=[_accepting()]) as vl:
+            msgs = vl.feed_chunks([_SILENCE] * 5)
+            self.assertFalse(
+                any(m.msg_type.startswith("recognizer_loop:") for m in msgs)
+            )
+
+    def test_raising_verifier_fails_open(self):
+        """A raising verifier does not suppress detection (fail-open)."""
+        with self._loop(verifiers=[_raising()]) as vl:
+            vl.assert_record_begin_emitted(vl.feed_chunks([_SILENCE] * 5))
+
+    def test_default_ww_instances(self):
+        """Omitting ww_instances uses a default hey_mycroft engine."""
+        with MiniVoiceLoop() as vl:
+            vl.assert_record_begin_emitted(vl.feed_chunks([_SILENCE] * 3))
+
+    def test_assert_wakeword_detected_helper(self):
+        """assert_wakeword_detected passes on a real detection."""
+        with self._loop() as vl:
+            vl.feed_chunks([_SILENCE] * 5)
+            vl.assert_wakeword_detected()  # operates on last feed result
+
+    def test_assert_wakeword_detected_fails_without_detection(self):
+        """assert_wakeword_detected raises when nothing fired."""
+        with self._loop(trigger_after=100) as vl:
+            vl.feed_chunks([_SILENCE] * 5)
+            with self.assertRaises(AssertionError):
+                vl.assert_wakeword_detected()
+
+    def test_factory(self):
+        """get_mini_voice_loop wires a usable harness."""
+        vl = get_mini_voice_loop(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=2)},
+        )
+        try:
+            vl.assert_record_begin_emitted(vl.feed_chunks([_SILENCE] * 3))
+        finally:
+            vl.shutdown()
+
+    def test_feed_file_full_sequence(self):
+        """feed_file drives the whole loop to a transcribed utterance."""
+        ww = MockHotWordEngine("hey_mycroft", trigger_after=2)
+        stt = MockStreamingSTT(transcript="what time is it")
+        with MiniVoiceLoop(ww_instances={"hey_mycroft": ww}, stt_instance=stt) as vl:
+            msgs = vl.feed_file(_wav(), silence_tail_chunks=30)
+            types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:record_begin", types)
+            self.assertIn("recognizer_loop:record_end", types)
+            vl.assert_utterance_emitted("what time is it", msgs)
+
+    def test_feed_file_empty_transcript_unknown(self):
+        """feed_file with no transcript emits the recognition-unknown event."""
+        ww = MockHotWordEngine("hey_mycroft", trigger_after=2)
+        with MiniVoiceLoop(ww_instances={"hey_mycroft": ww},
+                           stt_instance=MockStreamingSTT(transcript="")) as vl:
+            msgs = vl.feed_file(_wav(), silence_tail_chunks=30)
+            types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:speech.recognition.unknown", types)
+            self.assertNotIn("recognizer_loop:utterance", types)
+
+
+# ---------------------------------------------------------------------------
+# Verifier suppression gate (requires the hotword-verifier feature)
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(
+    HAS_VERIFY_GATE, "ovos-dinkum-listener build lacks the hotword-verifier gate"
+)
+class TestVerifierGate(unittest.TestCase):
+    """Tests that depend on DinkumVoiceLoop gating on hotwords.verify()."""
+
+    def test_reject_suppresses(self):
+        """A rejecting verifier suppresses the whole record sequence."""
+        ww = MockHotWordEngine("hey_mycroft", trigger_after=3)
+        with MiniVoiceLoop(
+            ww_instances={"hey_mycroft": ww}, verifiers=[_rejecting()]
+        ) as vl:
+            msgs = vl.feed_chunks([_SILENCE] * 5)
+            vl.assert_wakeword_suppressed(msgs)
+
+    def test_voice_loop_test_expect_suppressed(self):
+        """VoiceLoopTest(expect_record_begin=False) passes on rejection."""
+        VoiceLoopTest(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=3)},
+            verifiers=[_rejecting()],
+            audio_chunks=[_SILENCE] * 5,
+            expect_record_begin=False,
+        ).execute()
+
+
+# ---------------------------------------------------------------------------
+# VoiceLoopTest declarative helper (requires ovos-dinkum-listener)
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(HAS_DINKUM, "ovos-dinkum-listener not installed")
+class TestVoiceLoopTest(unittest.TestCase):
+    """VoiceLoopTest declarative helper tests."""
+
+    def test_expect_record_begin_passes(self):
+        """Passes when record_begin is expected and emitted."""
+        VoiceLoopTest(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=3)},
+            verifiers=[_accepting()],
+            audio_chunks=[_SILENCE] * 5,
+            expect_record_begin=True,
+        ).execute()
+
+    def test_expect_record_begin_fails_without_detection(self):
+        """Raises AssertionError when record_begin expected but absent."""
+        with self.assertRaises(AssertionError):
+            VoiceLoopTest(
+                ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=100)},
+                audio_chunks=[_SILENCE] * 5,
+                expect_record_begin=True,
+            ).execute()
+
+    def test_audio_file_with_expected_utterance(self):
+        """audio_file path drives the full loop and asserts the utterance."""
+        VoiceLoopTest(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=2)},
+            stt_instance=MockStreamingSTT(transcript="hello world"),
+            audio_file=_wav(),
+            expect_utterance="hello world",
+        ).execute()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #64.

## What

Adds in-process, file-driven harnesses for the three OVOS listener **services**, each wiring the real service to a `FakeBus` with mock mic/VAD/STT/wake-word plugins and capturing the `recognizer_loop:*` bus sequence. A shared `ListenerHarness` base provides bus capture and the common assertion helpers.

| Service | Harness | Drive |
|---|---|---|
| ovos-dinkum-listener | `MiniVoiceLoop` | `feed_chunks` (wake-word / verifier gate) + `feed_file` (full `DinkumVoiceLoop.run()`) |
| ovos-simple-listener | `MiniSimpleListener` | `feed_file` |
| mycroft-classic-listener | `MiniClassicListener` | `feed_file` (best-effort) + `bridge_recognizer_loop_to_bus` |

## #64 — `MiniVoiceLoop`

`feed_chunks(chunks)` feeds PCM through `DinkumVoiceLoop._detect_ww` and captures bus side-effects; the wake/listen callbacks emit the same events as the real service (`recognizer_loop:wakeword`, `…:record_begin`). Helpers `assert_wakeword_detected`, `assert_wakeword_suppressed`, `assert_record_begin_emitted`. `MiniHotwordContainer` carries a fail-open verifier chain. All four sequence flows from the issue are covered:

| Sequence | Expected |
|---|---|
| WW + all verifiers accept | `record_begin` emitted |
| WW + verifier rejects | suppressed |
| WW + verifier raises (fail-open) | `record_begin` emitted |
| No WW | no `recognizer_loop:*` |

The verifier gate lives in `DinkumVoiceLoop._detect_ww` (the hotword-verifier feature, e.g. ovos-dinkum-listener#191); the suppression tests are gated on the installed build having it.

## Beyond #64

- `feed_file` drives the **full** loop from an arbitrary audio file via a `MockFileMicrophone` mic plugin → `record_begin` → `record_end` → `utterance` / `speech.recognition.unknown`.
- `MiniSimpleListener` and `MiniClassicListener` cover the other two listener services (each will have its own e2e tests). The classic backend ships a reusable `RecognizerLoop`→`FakeBus` bridge plus a best-effort file drive.

## Tests

`test_voice_loop.py`, `test_simple_listener.py`, `test_classic_listener.py` — each dinkum/simple/classic-dependent test is gated on the optional listener package being importable, so they skip cleanly where it is not installed. Container/bridge unit tests run unconditionally. Docs: `docs/voice-loop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-process test harnesses for OVOS listener services (dinkum voice-loop, simple-listener, classic-listener) with file-driven audio input support
  * Harnesses include mock audio processors and assertion helpers for validating recognizer behavior

* **Documentation**
  * Added voice-loop testing documentation with examples and API reference

* **Tests**
  * Added comprehensive unit test coverage for new listener harnesses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->