### PR TITLE
fix: drop removed 'path' arg from pytest_pycollect_makemodule hook (pytest>=8 compat)

### DIFF
--- a/ovoscope/pytest_plugin.py
+++ b/ovoscope/pytest_plugin.py
@@ -422,7 +422,7 @@ def _autodiscover_intent_cases(config):
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_pycollect_makemodule(module_path, path, parent):
+def pytest_pycollect_makemodule(module_path, parent):
     """Auto-register intent-case tests on shim modules that declare
     ``ovoscope_intent_cases = {...}``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     # Alpha pin: 2.0.4 stable not yet released; 2.0.4a2 is the minimum that
     # includes the FakeBus-compatible SkillManager changes ovoscope depends on.
     "ovos-core>=2.0.4a2",
+    # ovoscope ships a pytest plugin (pytest11 entry point) -> pytest is a runtime
+    # dependency. >=8 is required: the pytest_pycollect_makemodule hook dropped the
+    # 'path' argument in pytest 8.
+    "pytest>=8",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -31,7 +35,6 @@ audio = ["ovos-audio>=1.2.0"]
 dev = [
     "ovos-audio>=1.2.0",
     "ovos-pydantic-models>=0.1.0",
-    "pytest",
     "pytest-cov",
 ]
 


### PR DESCRIPTION
## Summary

- pytest_pycollect_makemodule in ovoscope/pytest_plugin.py declared path as a hookimpl argument, but pytest removed that parameter in pytest 8. On pytest 9.1 this caused every test session loading the ovoscope plugin to crash at startup with PluginValidationError: Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec.
- Fix: drop path from the signature; keep module_path and parent, which are the current hookspec parameters.
- No behavioural change — path was not used inside the hook body.

## Verified against

- pytest 9.1.0 (latest at time of fix)
- python -m pytest --collect-only -q test/ — 433 tests collected, no PluginValidationError
- Full suite: 356 passed, 1 pre-existing failure (test_save_produces_json, unrelated), 76 skipped