### PR TITLE
fix(tts-intelligibility): score synthesis failures as total miss, not abort

### DIFF
--- a/ovoscope/tts_intelligibility.py
+++ b/ovoscope/tts_intelligibility.py
@@ -47,6 +47,7 @@ from typing import Any, List, Optional
 import jiwer
 
 from ovos_plugin_manager.utils.audio import AudioFile
+from ovos_utils.log import LOG
 
 # Module-level singleton for the reference STT — model load is expensive.
 _REFERENCE_STT: Optional[Any] = None
@@ -343,10 +344,18 @@ class TTSIntelligibilityHarness:
             An :class:`UtteranceScore`. On synthesis/transcription failure the
             transcript is empty and WER/CER reflect a total miss.
         """
-        if self.mode == "playback":
-            wav_path = self._render_playback(utterance)
-        else:
-            wav_path = self._render_direct(utterance)
+        try:
+            if self.mode == "playback":
+                wav_path = self._render_playback(utterance)
+            else:
+                wav_path = self._render_direct(utterance)
+        except Exception as exc:
+            # A synthesis failure (engine crash, missing model/binary, bad audio)
+            # is itself an intelligibility failure: score it as a total miss so the
+            # report is still produced and a marker is still emitted, instead of
+            # letting the exception abort the run with "no scores reported".
+            LOG.error(f"TTS synthesis failed for {utterance!r}: {exc}")
+            wav_path = None
 
         transcript = ""
         if wav_path and os.path.isfile(wav_path):

--- a/test/unittests/test_tts_intelligibility.py
+++ b/test/unittests/test_tts_intelligibility.py
@@ -188,5 +188,35 @@ class TestGracefulImport(unittest.TestCase):
         self.assertIn("OK", result.stdout)
 
 
+@unittest.skipUnless(TTS_AVAILABLE, "tts extra (jiwer/ovos-audio/normalizer) not installed")
+class TestSynthesisFailureResilience(unittest.TestCase):
+    """A get_tts crash must score as a total miss, not abort the whole run."""
+
+    def test_synthesis_failure_scores_total_miss(self):
+        from ovoscope import tts_intelligibility as ti
+
+        class BoomTTS:
+            def get_tts(self, *args, **kwargs):
+                raise RuntimeError("synthesis exploded")
+
+        class EchoSTT:
+            def execute(self, audio, language=None):
+                return "anything"
+
+        harness = ti.TTSIntelligibilityHarness(
+            BoomTTS(), lang="en-US", reference_stt=EchoSTT(), mode="direct",
+        )
+        with harness:
+            report = harness.score(["hello world", "good morning"])
+
+        # The run completes and every utterance is scored a total miss (WER 1.0)
+        # rather than the exception propagating and emitting no marker at all.
+        self.assertEqual(len(report.scores), 2)
+        self.assertEqual(report.mean_wer, 1.0)
+        # The report still serialises, so the test's marker can be emitted.
+        import json
+        json.loads(json.dumps(report.to_dict()))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When a TTS engine's `get_tts()` raises in CI (missing system binary/model, bad audio, engine error), the exception propagated out of `score()` so the per-plugin test never reached its `print("::TTS-INTELLIGIBILITY:: ...")` — the PR comment then showed **'No intelligibility scores reported'** instead of a real result.

Fix: wrap the render call in `score_one` — a synthesis failure is itself an intelligibility failure, so it scores as a total miss (WER 1.0), the report is still produced, the marker is still emitted, and the gate correctly fails the unintelligible engine **with the score visible**. Adds a regression test (`BoomTTS` whose get_tts raises → report returned, mean WER 1.0).

Reaches CI immediately for callers with `pre_release: true` (which git-install ovoscope@dev).