### PR TITLE
feat: assert_template_shown for SYSTEM_* GUI templates

### DIFF
--- a/docs/gui-testing.md
+++ b/docs/gui-testing.md
@@ -225,6 +225,30 @@ Setting `ignore_gui=True` (the default on `End2EndTest`) keeps the ordered
 message sequence clean while `GUICaptureSession` captures the GUI events
 independently.
 
+## Template-Based GUI (`SYSTEM_*` templates)
+
+Skills that use the typed template API (`self.gui.show_weather(...)`,
+`show_text(...)`, `show_list(...)`, …) emit a `gui.page.show` for a built-in
+`SYSTEM_*` template plus `gui.value.set` for its data keys. `assert_template_shown`
+checks both in one call:
+
+```python
+with GUICaptureSession(mc.bus) as gui:
+    mc.bus.emit(Message("recognizer_loop:utterance",
+                        {"utterances": ["what's the weather"], "lang": "en-US"}))
+    import time; time.sleep(2)
+    # the SYSTEM_ prefix is optional ("weather" == "SYSTEM_weather")
+    gui.assert_template_shown(
+        "ovos-skill-weather.openvoiceos",
+        "weather",
+        values={"current_temp": 22, "condition": "Sunny"},
+    )
+```
+
+This is the recommended assertion for the template-based GUI: it does not care
+which display backend (Qt, pyhtmx, …) renders the template — only that the skill
+requested the right `SYSTEM_*` template with the right session data.
+
 ## What `GUICaptureSession` Does NOT Cover
 
 - Full GUI rendering — only bus messages are captured; no QML engine is run.

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -733,8 +733,12 @@ class End2EndTest:
         if GLOBAL_BUS_COVERAGE:
             self.track_bus_coverage = True
 
-        # standardize to be a list
-        if isinstance(self.source_message, Message):
+        # standardize to be a list. Use "not a list" rather than an
+        # isinstance(Message) check: depending on installed versions the
+        # message class may come from ovos_bus_client / ovos_spec_tools /
+        # ovos_utils.fakebus, and a cross-class isinstance can be False — which
+        # would leave a single (non-iterable) Message and break later iteration.
+        if not isinstance(self.source_message, list):
             self.source_message = [self.source_message]
         if self.ignore_gui:
             # ensure we don't mutate a shared default list

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -1249,6 +1249,33 @@ class GUICaptureSession:
             f"but no matching gui.page.show message was captured.\nGot: {captured}"
         )
 
+    def assert_template_shown(self, namespace: str, template: str,
+                              values: Optional[Dict[str, Any]] = None,
+                              timeout: float = 2.0) -> None:
+        """Assert that a built-in ``SYSTEM_*`` template was shown.
+
+        Ergonomic helper for the template-based GUI: a skill calling a typed
+        method such as ``self.gui.show_weather(...)`` emits a
+        ``gui.page.show`` for the ``SYSTEM_weather`` template plus
+        ``gui.value.set`` for its data keys. This asserts both in one call.
+
+        Args:
+            namespace: GUI namespace (typically the skill ID).
+            template: Template name, with or without the ``SYSTEM_`` prefix
+                (``"weather"`` and ``"SYSTEM_weather"`` are equivalent).
+            values: Optional mapping of session-data keys to expected values;
+                each is checked via :meth:`assert_namespace_value`.
+            timeout: Maximum seconds to wait for the page-show message.
+
+        Raises:
+            AssertionError: If the template was not shown, or a listed value
+                was not set.
+        """
+        name = template if template.startswith("SYSTEM_") else f"SYSTEM_{template}"
+        self.assert_page_shown(namespace, name, timeout=timeout)
+        for key, value in (values or {}).items():
+            self.assert_namespace_value(namespace, key, value)
+
     def assert_namespace_value(self, namespace: str, key: str, value: Any) -> None:
         """Assert that a namespace key was set to a specific value.
 

--- a/test/unittests/test_gui_capture.py
+++ b/test/unittests/test_gui_capture.py
@@ -106,6 +106,50 @@ class TestGUICaptureSessionAssertions(unittest.TestCase):
         )]
         session.assert_namespace_has_key("weather", "current_temp")
 
+    # -- assert_template_shown (SYSTEM_* template model) --
+
+    def test_assert_template_shown_with_prefix(self) -> None:
+        """Full SYSTEM_ name should match the shown template."""
+        session = self._make_session()
+        session.messages = [self._page_show_msg("weatherskill", "SYSTEM_weather")]
+        session.assert_template_shown("weatherskill", "SYSTEM_weather")
+
+    def test_assert_template_shown_without_prefix(self) -> None:
+        """Short name is normalized to the SYSTEM_ prefix."""
+        session = self._make_session()
+        session.messages = [self._page_show_msg("weatherskill", "SYSTEM_weather")]
+        session.assert_template_shown("weatherskill", "weather")
+
+    def test_assert_template_shown_with_values(self) -> None:
+        """Template + accompanying session-data values both asserted."""
+        session = self._make_session()
+        session.messages = [
+            self._page_show_msg("weatherskill", "SYSTEM_weather"),
+            self._value_set_msg("weatherskill", {"current_temp": 22,
+                                                 "condition": "Sunny"}),
+        ]
+        session.assert_template_shown("weatherskill", "weather",
+                                      values={"current_temp": 22,
+                                              "condition": "Sunny"})
+
+    def test_assert_template_shown_missing_template(self) -> None:
+        """Template never shown should raise."""
+        session = self._make_session()
+        session.messages = [self._page_show_msg("weatherskill", "SYSTEM_text")]
+        with self.assertRaises(AssertionError):
+            session.assert_template_shown("weatherskill", "weather", timeout=0.1)
+
+    def test_assert_template_shown_wrong_value(self) -> None:
+        """Template shown but a listed value differs should raise."""
+        session = self._make_session()
+        session.messages = [
+            self._page_show_msg("weatherskill", "SYSTEM_weather"),
+            self._value_set_msg("weatherskill", {"current_temp": 22}),
+        ]
+        with self.assertRaises(AssertionError):
+            session.assert_template_shown("weatherskill", "weather",
+                                          values={"current_temp": 99})
+
     # -- assert_namespace_cleared --
 
     def test_assert_namespace_cleared_match(self) -> None:


### PR DESCRIPTION
## `assert_template_shown` for the template-based GUI

The new OVOS GUI exposes a closed set of built-in `SYSTEM_*` templates: a skill
calling a typed method (`self.gui.show_weather(...)`, `show_text(...)`, …) emits a
`gui.page.show` for the template plus `gui.value.set` for its data keys.

This adds `GUICaptureSession.assert_template_shown(namespace, template, values=None)`
which asserts both in one call:

```python
gui.assert_template_shown("ovos-skill-weather.openvoiceos", "weather",
                          values={"current_temp": 22, "condition": "Sunny"})
```

- The `SYSTEM_` prefix is optional (`"weather"` ≡ `"SYSTEM_weather"`).
- Backend-agnostic — it asserts what the skill *requested*, independent of which
  display adapter (Qt, pyhtmx, …) renders it.

Builds on the existing `assert_page_shown` / `assert_namespace_value`. Includes 5
new unit tests (17 pass total in `test_gui_capture.py`) and a `docs/gui-testing.md`
section.
