### PR TITLE
fix: repair ovoscope record in-process path (default_pipeline kwarg + from_message skill_ids)

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -1029,7 +1029,7 @@ class End2EndTest:
                                  async_messages=async_messages)
 
         for idx, source_message in enumerate(message):
-            if "session" not in source_message.context:
+            if "session" not in source_message.context and len(capture.responses):
                 # propagate session updates as a client would do
                 source_message.context["session"] = capture.responses[-1].context["session"]
             capture.capture(source_message, timeout)

--- a/ovoscope/cli.py
+++ b/ovoscope/cli.py
@@ -78,7 +78,7 @@ def _record_inprocess(args: argparse.Namespace) -> int:
         Exit code (0 = success, 1 = failure).
     """
     try:
-        from ovoscope import End2EndTest, get_minicroft
+        from ovoscope import End2EndTest
         from ovos_utils.messagebus import Message
     except ImportError as exc:
         _die(f"ovoscope import failed: {exc}")
@@ -88,26 +88,29 @@ def _record_inprocess(args: argparse.Namespace) -> int:
     pipeline: Optional[List[str]] = args.pipeline.split(",") if args.pipeline else None
     timeout: float = args.timeout
 
+    src_msg = Message(
+        "recognizer_loop:utterance",
+        data={"utterances": [args.utterance], "lang": lang},
+    )
+
+    # from_message owns the MiniCroft lifecycle: it loads the skills, emits the
+    # source utterance, captures the response sequence, and stops MiniCroft.
+    # Loading a MiniCroft here as well would double-load the skill plugins.
     print(f"[record] Loading skills: {skill_ids}")
+    print(f"[record] Sending utterance: {args.utterance!r}")
     try:
-        mc = get_minicroft(skill_ids, lang=lang, pipeline=pipeline, max_wait=60)
+        from_message_kwargs = {"lang": lang, "timeout": timeout}
+        if pipeline is not None:
+            # MiniCroft's pipeline override kwarg is `default_pipeline`; it is
+            # forwarded through from_message -> get_minicroft -> MiniCroft.
+            from_message_kwargs["default_pipeline"] = pipeline
+        test = End2EndTest.from_message(src_msg, skill_ids, **from_message_kwargs)
     except TimeoutError:
         _die("MiniCroft did not reach READY state in time.")
 
-    try:
-        src_msg = Message(
-            "recognizer_loop:utterance",
-            data={"utterances": [args.utterance], "lang": lang},
-        )
-
-        print(f"[record] Sending utterance: {args.utterance!r}")
-        test = End2EndTest.from_message(src_msg, mc, timeout=timeout)
-
-        test.save(args.output)
-        print(f"[record] Fixture saved to {args.output}")
-        return 0
-    finally:
-        mc.stop()
+    test.save(args.output)
+    print(f"[record] Fixture saved to {args.output}")
+    return 0
 
 
 def _record_live(args: argparse.Namespace) -> int:


### PR DESCRIPTION
Closes #84

`ovoscope record` (the default in-process path; only `--live` bypasses it) raised on every invocation.

Root cause in `_record_inprocess` (`ovoscope/cli.py`):
1. `get_minicroft(..., pipeline=...)` forwarded `pipeline=` to `MiniCroft`, whose actual kwarg is `default_pipeline` → `TypeError`.
2. `End2EndTest.from_message(src_msg, mc, ...)` passed a `MiniCroft` where `from_message` expects `skill_ids: List[str]`.

`from_message` is the canonical in-process recording API: it loads its own MiniCroft, emits the source utterance, captures the response sequence, and stops MiniCroft. The old code also pre-created a separate MiniCroft, so the path double-loaded skill plugins. This change drops the redundant load and lets `from_message` own the MiniCroft lifecycle, forwarding `--pipeline` as `default_pipeline` only when explicitly set (preserving default-pipeline auto-detection otherwise).

Also fixes a latent `IndexError` in `from_message`: the first source message with no session context (exactly what `cmd_record` builds: `recognizer_loop:utterance`) hit `capture.responses[-1]` on an empty list. Guarded with `and len(capture.responses)`, matching the identical guard already in `execute()`.

Verified: driving `cli.cmd_record` in-process against a trivial skill returns 0 and writes a valid fixture (`source_message` + `expected_messages`); existing `from_message` unit tests pass.

Found during a source-validation pass of the OVOS Technical Manual.