### PR TITLE
feat: stream audio frames through MiniListener for multi-frame decoders

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,5 +11,5 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
-      install_extras: 'audio,pydantic,media'
+      install_extras: 'audio,pydantic,media,listener'
       test_path: 'test/unittests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,5 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'ovoscope'
       test_path: 'test/unittests/'
-      test_extras: 'audio,pydantic,media'
+      test_extras: 'audio,pydantic,media,listener'
       min_coverage: 0

--- a/docs/listener.md
+++ b/docs/listener.md
@@ -68,6 +68,32 @@ assert any(m.msg_type == "recognizer_loop:utterance" for m in msgs)
 listener.shutdown()
 ```
 
+**Streaming real ggwave audio** — the ggwave decoder only fires after it has
+accumulated enough frames, so feed the whole waveform with `feed_audio_stream`,
+which keeps every message emitted across the stream (unlike `feed_audio`, which
+clears its buffer on each call):
+
+```python
+import ggwave, numpy as np
+from ovos_audio_transformer_plugin_ggwave import GGWavePlugin
+from ovoscope.listener import get_mini_listener
+
+# real ggwave waveform (48kHz float32 → 16kHz int16, as the mic would deliver it)
+wf = np.frombuffer(ggwave.encode("UTT:turn on the lights", protocolId=1, volume=20),
+                   dtype=np.float32)
+mic = np.interp(np.linspace(0, len(wf) - 1, int(len(wf) * 16000 / 48000)),
+                np.arange(len(wf)), wf)
+audio = (np.clip(mic, -1, 1) * 32767).astype(np.int16).tobytes()
+
+plugin = GGWavePlugin(config={"start_enabled": True, "sample_rate": 16000})
+listener = get_mini_listener(
+    plugin_instances={"ovos-audio-transformer-plugin-ggwave": plugin}
+)
+msgs = listener.feed_audio_stream(audio, chunk_size=2048)
+assert any(m.msg_type == "recognizer_loop:utterance" for m in msgs)
+listener.shutdown()
+```
+
 **Full pipeline testing** (STT with real WAV):
 
 ```python
@@ -105,6 +131,7 @@ listener.shutdown()
 |--------|-----------|-------------|
 | `feed_audio(chunk)` — `ovoscope/listener.py:351` | `(bytes) → List[Message]` | Calls `AudioTransformersService.feed_audio()`. Requires `ovos-dinkum-listener`. |
 | `feed_speech(chunk)` — `ovoscope/listener.py:371` | `(bytes) → List[Message]` | Calls `AudioTransformersService.feed_speech()`. Requires `ovos-dinkum-listener`. |
+| `feed_audio_stream(chunks, feed, chunk_size)` | `(bytes\|list[bytes], str, int) → List[Message]` | Streams frames in order **without** clearing between them; aggregates all emitted messages. Use for decoders that fire after many frames (ggwave). |
 | `transform(chunk)` — `ovoscope/listener.py:390` | `(bytes) → tuple[bytes, dict, List[Message]]` | Full transform pipeline; returns `(audio, ctx, messages)`. Requires `ovos-dinkum-listener`. |
 | `listen(audio, ...)` — `ovoscope/listener.py:410` | `(audio, language, stt_instance, ...) → List[Message]` | Full pipeline: audio → transformers → STT → utterance message. Requires `ovos-dinkum-listener`. |
 

--- a/ovoscope/listener.py
+++ b/ovoscope/listener.py
@@ -402,6 +402,59 @@ class MiniListener:
         audio, ctx = self.transformers.transform(chunk)
         return audio, ctx, list(self._messages)
 
+    def feed_audio_stream(
+        self,
+        chunks: Union[bytes, List[bytes]],
+        feed: str = "feed_audio",
+        chunk_size: int = 2048,
+    ) -> List[Message]:
+        """Stream a sequence of audio frames and aggregate emitted messages.
+
+        Unlike :meth:`feed_audio` / :meth:`feed_speech`, which clear the
+        capture buffer on every call, this feeds each frame in order and keeps
+        every message emitted across the **whole** stream.  This is required
+        for transformers whose decoder only fires after accumulating many
+        frames of audio (e.g. ggwave data-over-sound).
+
+        Args:
+            chunks: Either a flat ``bytes`` object (split into *chunk_size*
+                frames internally) or a pre-segmented ``List[bytes]`` of frames.
+            feed: Which transformer feed to drive per frame —
+                ``"feed_audio"`` (non-speech) or ``"feed_speech"``.
+            chunk_size: Bytes per frame when *chunks* is a flat ``bytes``
+                object (ignored when *chunks* is already a list).
+
+        Returns:
+            All ``Message`` objects emitted on the bus across every frame.
+
+        Raises:
+            RuntimeError: If ``ovos-dinkum-listener`` is not installed.
+            ValueError: If *feed* is not a recognised feed method.
+        """
+        if self.transformers is None:
+            raise RuntimeError(
+                "ovos-dinkum-listener is required for feed_audio_stream. "
+                "Install it with: pip install ovos-dinkum-listener"
+            )
+        if feed not in ("feed_audio", "feed_speech"):
+            raise ValueError(
+                f"feed must be 'feed_audio' or 'feed_speech', got {feed!r}"
+            )
+
+        if isinstance(chunks, bytes):
+            frames = [
+                chunks[i:i + chunk_size]
+                for i in range(0, len(chunks), chunk_size)
+            ]
+        else:
+            frames = list(chunks)
+
+        feeder = getattr(self.transformers, feed)
+        self._messages.clear()
+        for frame in frames:
+            feeder(frame)
+        return list(self._messages)
+
     def listen(
         self,
         audio: Union[bytes, str, Path],
@@ -758,8 +811,17 @@ class ListenerTest:
     """Raw audio bytes to inject into the pipeline."""
 
     feed_method: str = "feed_audio"
-    """Which feed method to call: ``"feed_audio"``, ``"feed_speech"``, or
-    ``"transform"``."""
+    """Which feed method to call: ``"feed_audio"``, ``"feed_speech"``,
+    ``"feed_audio_stream"``, ``"transform"``, or ``"listen"``.
+
+    Use ``"feed_audio_stream"`` for transformers that decode only after
+    accumulating many frames (e.g. ggwave): *audio_input* is split into
+    *chunk_size* frames, fed in order, and all emitted messages are
+    aggregated across the whole stream."""
+
+    chunk_size: int = 2048
+    """Frame size (bytes) used to split *audio_input* when *feed_method* is
+    ``"feed_audio_stream"``."""
 
     expected_types: List[str] = field(default_factory=list)
     """Message types that MUST appear in the captured output."""
@@ -787,11 +849,14 @@ class ListenerTest:
             stt_instance=self.stt_instance,
         )
         try:
-            method = getattr(listener, self.feed_method)
             if self.feed_method == "listen":
                 messages = listener.listen(self.audio_input)
+            elif self.feed_method == "feed_audio_stream":
+                messages = listener.feed_audio_stream(
+                    self.audio_input, chunk_size=self.chunk_size
+                )
             else:
-                result = method(self.audio_input)
+                result = getattr(listener, self.feed_method)(self.audio_input)
                 if self.feed_method == "transform":
                     messages: List[Message] = result[2]
                 else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ pydantic = ["ovos-pydantic-models>=0.1.0"]
 audio = ["ovos-audio>=1.2.0"]
 # OCP / ovos-media player harnesses (ovoscope.media: OCPPlayerHarness, ...).
 media = ["ovos-media>=0.0.2a3"]
+# MiniListener plugin_instances path (feed_audio_stream) needs the dinkum
+# AudioTransformersService. >=0.7.2a1 is the first release that allows
+# ovos-bus-client 2.x (older pins cap it <2.0.0 and conflict with ovos-core).
+listener = ["ovos-dinkum-listener>=0.7.2a1"]
 # End-to-end TTS intelligibility scoring (WER/CER round-trip via reference STT).
 # faster-whisper itself is pulled by the plugin — don't list it here to avoid
 # version skew.
@@ -46,6 +50,7 @@ tts = [
 dev = [
     "ovos-audio>=1.2.0",
     "ovos-media>=0.0.2a3",
+    "ovos-dinkum-listener>=0.7.2a1",
     "ovos-pydantic-models>=0.1.0",
     "jiwer",
     "ovos-utterance-normalizer",

--- a/test/unittests/test_listener_stream.py
+++ b/test/unittests/test_listener_stream.py
@@ -1,0 +1,154 @@
+# Copyright 2024 Jarbas AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for MiniListener.feed_audio_stream and ListenerTest streaming.
+
+Uses a self-contained stub transformer (no native ggwave dependency) that only
+emits its message after accumulating a threshold number of frames — exactly the
+behaviour ``feed_audio_stream`` exists to support.
+"""
+import unittest
+
+from ovos_bus_client.message import Message
+from ovoscope.listener import ListenerTest, MiniListener, get_mini_listener
+
+
+_BASE_CONFIG = {"listener": {"audio_transformers": {}}}
+
+
+class _AccumulatingTransformer:
+    """Stub audio transformer that fires only after N fed frames.
+
+    Mirrors a real streaming decoder: a single ``feed_audio`` call never
+    produces output, so the aggregating ``feed_audio_stream`` is required to
+    observe the emitted message.
+    """
+
+    def __init__(self, trigger_after=3, msg_type="recognizer_loop:utterance"):
+        self.name = "stub"
+        self.priority = 10
+        self.trigger_after = trigger_after
+        self.msg_type = msg_type
+        self.count = 0
+        self.bus = None
+
+    def bind(self, bus):
+        self.bus = bus
+
+    def feed_audio_chunk(self, chunk):
+        self.count += 1
+        if self.count == self.trigger_after:
+            self.bus.emit(Message(self.msg_type, {"utterances": ["streamed"]}))
+
+    def feed_speech_chunk(self, chunk):
+        self.feed_audio_chunk(chunk)
+
+    def shutdown(self):
+        pass
+
+
+def _listener(trigger_after=3):
+    plugin = _AccumulatingTransformer(trigger_after=trigger_after)
+    return get_mini_listener(
+        config=_BASE_CONFIG,
+        plugin_instances={"stub": plugin},
+    )
+
+
+class TestFeedAudioStream(unittest.TestCase):
+    """MiniListener.feed_audio_stream aggregation behaviour."""
+
+    def test_single_feed_audio_misses_late_decode(self):
+        """A lone feed_audio call before the threshold yields nothing."""
+        listener = _listener(trigger_after=3)
+        try:
+            self.assertEqual(listener.feed_audio(b"\x00" * 100), [])
+        finally:
+            listener.shutdown()
+
+    def test_stream_aggregates_across_frames(self):
+        """feed_audio_stream keeps the message emitted on a later frame."""
+        listener = _listener(trigger_after=3)
+        try:
+            msgs = listener.feed_audio_stream([b"\x00" * 100] * 5)
+            types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:utterance", types)
+        finally:
+            listener.shutdown()
+
+    def test_stream_splits_flat_bytes_by_chunk_size(self):
+        """A flat bytes object is split into chunk_size frames."""
+        listener = _listener(trigger_after=4)
+        try:
+            # 4 frames of 50 bytes -> fourth frame triggers
+            msgs = listener.feed_audio_stream(b"\x00" * 200, chunk_size=50)
+            self.assertTrue(
+                any(m.msg_type == "recognizer_loop:utterance" for m in msgs)
+            )
+        finally:
+            listener.shutdown()
+
+    def test_stream_feed_speech_path(self):
+        """feed='feed_speech' drives the speech feed instead of audio."""
+        listener = _listener(trigger_after=2)
+        try:
+            msgs = listener.feed_audio_stream(
+                [b"\x00" * 100] * 3, feed="feed_speech"
+            )
+            self.assertTrue(
+                any(m.msg_type == "recognizer_loop:utterance" for m in msgs)
+            )
+        finally:
+            listener.shutdown()
+
+    def test_invalid_feed_raises(self):
+        """An unknown feed method is rejected."""
+        listener = _listener()
+        try:
+            with self.assertRaises(ValueError):
+                listener.feed_audio_stream([b"\x00" * 10], feed="nope")
+        finally:
+            listener.shutdown()
+
+
+class TestListenerTestStreaming(unittest.TestCase):
+    """ListenerTest declarative streaming support."""
+
+    def test_listener_test_feed_audio_stream(self):
+        """ListenerTest with feed_method='feed_audio_stream' aggregates."""
+        plugin = _AccumulatingTransformer(trigger_after=3)
+        ListenerTest(
+            config=_BASE_CONFIG,
+            plugin_instances={"stub": plugin},
+            audio_input=b"\x00" * 300,
+            feed_method="feed_audio_stream",
+            chunk_size=100,
+            expected_types=["recognizer_loop:utterance"],
+        ).execute()
+
+    def test_listener_test_forbidden_absent(self):
+        """forbidden_types passes when the type never appears."""
+        plugin = _AccumulatingTransformer(trigger_after=2)
+        ListenerTest(
+            config=_BASE_CONFIG,
+            plugin_instances={"stub": plugin},
+            audio_input=b"\x00" * 200,
+            feed_method="feed_audio_stream",
+            chunk_size=100,
+            expected_types=["recognizer_loop:utterance"],
+            forbidden_types=["speak"],
+        ).execute()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Add `MiniListener.feed_audio_stream(chunks, feed=..., chunk_size=...)`, which feeds a sequence of audio frames in order and aggregates **every** message emitted across the whole stream — instead of `feed_audio`/`feed_speech`, which clear the capture buffer on each call.

## Why

Audio transformers whose decoder only fires after accumulating many frames (e.g. the ggwave data-over-sound plugin) emit their result on some late frame. With the per-call `feed_audio`, that message is lost. `feed_audio_stream` makes such transformers testable end-to-end with real audio.

## Changes

- `MiniListener.feed_audio_stream` (bytes or list-of-frames; `feed_audio`/`feed_speech` selectable).
- `ListenerTest` gains `feed_method="feed_audio_stream"` and `chunk_size`.
- docs/listener.md: real-ggwave streaming example + API row.
- Unit tests using a self-contained stub accumulating transformer (no native deps).

## Test plan

`uv run pytest test/ -v` — full suite green (377 passed, 75 skipped); new `test_listener_stream.py` (7 tests) passing. Verified end-to-end against the real ggwave plugin feeding a genuine waveform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio streaming support for listener inputs, allowing frames to be processed in sequence and returning all emitted messages from the full stream.
  * Expanded listener test support to cover streaming audio scenarios and chunked input handling.

* **Documentation**
  * Updated listener docs with a quick-start example for streaming audio and an API reference for the new streaming method.

* **Tests**
  * Added unit tests covering streaming behavior, chunk splitting, speech routing, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->