### PR TITLE
fix: pytest 9 compatibility for the pytest11 plugin

### DIFF
--- a/ovoscope/pytest_plugin.py
+++ b/ovoscope/pytest_plugin.py
@@ -421,33 +421,39 @@ def _autodiscover_intent_cases(config):
     return None
 
 
-@pytest.hookimpl(hookwrapper=True)
+@pytest.hookimpl(wrapper=True)
 def pytest_pycollect_makemodule(module_path, parent):
     """Auto-register intent-case tests on shim modules that declare
     ``ovoscope_intent_cases = {...}``.
 
-    The hookwrapper imports the module first, lets pytest build the
+    The hook wrapper imports the module first, lets pytest build the
     collector, then injects the generated TestCase classes into the
     module's namespace so the standard Python-class collector finds them.
+
+    Uses the modern ``wrapper=True`` hook-wrapper protocol (pluggy >=1.2 /
+    pytest >=7.2): the downstream result arrives from ``yield`` and is
+    returned unchanged. The legacy ``hookwrapper=True`` /
+    ``outcome.get_result()`` protocol is removed in pytest 10, so we adopt
+    the new one to stay loadable under pytest 8 and 9.
     """
     from ovoscope.intent_cases import autodiscover_from_conftest
 
-    outcome = yield
-    collector = outcome.get_result()
+    collector = yield
     if collector is None:
-        return
+        return collector
     try:
         mod = collector.obj  # imports the module if not already loaded
     except Exception:
-        return
+        return collector
     if not hasattr(mod, "ovoscope_intent_cases"):
-        return
+        return collector
     if getattr(mod, "_ovoscope_intent_cases_registered", False):
-        return
+        return collector
     try:
         autodiscover_from_conftest(Path(mod.__file__).parent, mod.__dict__)
     except Exception as exc:  # noqa: BLE001
         print(f"ovoscope auto-discovery skipped for {mod.__file__}: {exc}")
+    return collector
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
## Problem

ovoscope ships a `pytest11` entry point (`ovoscope.pytest_plugin`), so pytest auto-loads it at collection in any project that has ovoscope installed. Under pytest 9 the plugin failed to load and broke unrelated suites (#87), forcing consumers to run with `-p no:ovoscope`.

Two distinct pytest-9 incompatibilities exist in this hook:

1. **Removed hookspec arg** — `pytest_pycollect_makemodule(module_path, path, parent)` declared `path`, which pytest 8 dropped from the hookspec, giving `PluginValidationError: Argument(s) {'path'} ... can not be found in the hookspec`. This was the symptom in #87's traceback. (Already addressed on dev by #73.)
2. **Legacy hook-wrapper protocol** — the hook used `@pytest.hookimpl(hookwrapper=True)` with `outcome = yield` / `outcome.get_result()`. This is the deprecated wrapper protocol; pytest 9 standardizes on `wrapper=True` and the legacy form is slated for removal. This PR migrates it so the plugin stays forward-compatible.

## Fix

`ovoscope/pytest_plugin.py` — migrate `pytest_pycollect_makemodule` to the modern `@pytest.hookimpl(wrapper=True)` protocol: the downstream collector now comes directly from `yield` and is `return`ed unchanged after intent-case auto-discovery. Behavior is identical; only the wrapper calling convention changes. `wrapper=True` is supported since pluggy 1.2 / pytest 7.2, so this works on the `pytest>=8` floor and on pytest 9.

The entry point is **kept** — fixtures still register; only the incompatibility is fixed.

## Verification

- Reproduced #87's exact `PluginValidationError` under pytest 9.1.1 with the old signature; confirmed it's gone.
- Fresh venv, `pip install -e .[dev]` + `pytest>=9` (9.1.1): trivial test collects **without** `-p no:ovoscope`, plugin loads with **no error and no `PytestDeprecationWarning`** (even under `-W error::pytest.PytestDeprecationWarning`).
- Same on pytest 8.4.2 (the floor).
- ovoscope's own suite: intent-case / auto-discovery tests (which exercise this hook) pass on both 8 and 9; full suite 426 passed / 18 skipped.

Closes #87
