### PR TITLE
feat: export ovos-media OCP harness from the package + add [media] extra

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,5 +11,5 @@ jobs:
     secrets: inherit
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
-      install_extras: 'audio,pydantic'
+      install_extras: 'audio,pydantic,media'
       test_path: 'test/unittests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,4 +13,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'ovoscope'
       test_path: 'test/unittests/'
+      test_extras: 'audio,pydantic,media'
       min_coverage: 0

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@
 | [end2end-test.md](end2end-test.md) | `End2EndTest` — full test runner reference |
 | [pydantic-integration.md](pydantic-integration.md) | Using `ovos-pydantic-models` with OvoScope |
 | [audio-testing.md](audio-testing.md) | `AudioServiceHarness`, `PlaybackServiceHarness` — testing audio services |
+| [media-testing.md](media-testing.md) | `OCPPlayerHarness`, `OCPCaptureSession`, `MockOCPBackend` — testing the `ovos-media` OCP player (and driving a real OCP backend) |
+| [media-provider-testing.md](media-provider-testing.md) | `MediaProviderHarness` — testing `opm.media.provider` catalog/search plugins |
+| [ocp.md](ocp.md) | `OCPTest` — testing legacy OCP search skills (`@ocp_search`) |
 | [listener.md](listener.md) | `MiniListener`, `get_mini_listener`, `ListenerTest`, `MockVADEngine`, `MockHotWordEngine`, `VADTest`, `WakeWordTest` — testing audio transformer plugins, STT pipeline, VAD, and wake-word |
 | [voice-loop.md](voice-loop.md) | `MiniVoiceLoop` / `MiniSimpleListener` / `MiniClassicListener` — file-driven bus-sequence testing for the ovos-dinkum, ovos-simple, and mycroft-classic listener services (wake-word → record-begin → utterance), with verifier-chain gating |
 | [gui-testing.md](gui-testing.md) | `GUICaptureSession` — asserting GUI page navigation and namespace values |

--- a/docs/media-provider-testing.md
+++ b/docs/media-provider-testing.md
@@ -1,0 +1,97 @@
+# MediaProvider (Search) Testing with ovoscope
+
+`MediaProviderHarness` (`ovoscope.media_provider`) tests `opm.media.provider`
+plugins — the in-process **catalog/search** providers introduced by the
+ovos-media sprint to replace OCP search skills. It is the search-side counterpart
+to [`OCPPlayerHarness`](media-testing.md), which drives the *player*.
+
+> **No extra required.** Unlike the player harness, `MediaProviderHarness` is
+> **duck-typed**: it imports neither `mediavocab` nor `ovos-plugin-manager`'s
+> `MediaProvider` / `QueryContext`. Your *test* supplies the `Signals` /
+> `QueryContext` objects, so ovoscope itself stays dependency-free. The provider
+> package and `mediavocab` only need to be installed for the test that uses it.
+
+## Why a dedicated harness
+
+There is no released loader for the `opm.media.provider` entry-point group, and
+the OCP pipeline does not yet load providers in-process. So the harness models the
+pipeline's *intended* path and removes the boilerplate every provider e2e would
+otherwise repeat:
+
+```
+discover the entry-point  ->  serves(signals, context) gate  ->  search_safe()
+```
+
+## Basic usage
+
+```python
+from ovoscope import MediaProviderHarness
+from mediavocab import MediaType, Signals
+from ovos_plugin_manager.templates.media_provider import QueryContext
+
+h = MediaProviderHarness.from_entrypoint(
+    "music_assistant",                       # opm.media.provider entry-point name
+    config={"url": "http://mass.local:8095"},
+    mock_api=my_mock_client,                 # injected onto provider._api
+)
+
+# packaging registered the plugin
+h.assert_entrypoint_registered()
+
+# three-axis + context routing gate
+h.assert_routes(Signals(medium=MediaType.MUSIC),
+                QueryContext(supported_playback_types={"audio"}))
+h.assert_not_routes(Signals(medium=MediaType.MUSIC),
+                    QueryContext(supported_playback_types={"video"}))  # audio-only provider
+h.assert_not_routes(Signals(medium=MediaType.MOVIE))
+
+# the never-raising search the pipeline calls — ranked, playable results
+releases = h.assert_returns_playables(Signals(title="worms"))
+assert all(r.uri.startswith("library://") for r in releases)
+```
+
+## Constructing the harness
+
+| Constructor | Use |
+|---|---|
+| `MediaProviderHarness.from_entrypoint(name, config=None, group="opm.media.provider", mock_api=None, api_attr="_api")` | Discover the provider through its installed entry-point (the real e2e). Raises `AssertionError` if the entry-point is missing or ambiguous. |
+| `MediaProviderHarness.from_class(provider_cls, config=None, mock_api=None, api_attr="_api")` | Wrap a class you already hold (no packaging needed) — handy for unit tests. |
+
+`mock_api` is set onto `provider.<api_attr>` (default `_api`) to bypass the lazy,
+network-backed client a provider builds on first use.
+
+## Drivers
+
+Thin pass-throughs mirroring the `MediaProvider` contract:
+
+| Method | Delegates to |
+|---|---|
+| `is_available()` | `provider.is_available()` |
+| `serves(signals, context=None)` | `provider.serves(...)` |
+| `search(signals, lang="en-us")` | `provider.search(...)` (may raise) |
+| `search_safe(signals, context=None, lang="en-us")` | `provider.search_safe(...)` (never raises) |
+| `featured_media(lang="en-us")` | `provider.featured_media(...)` |
+
+## Assertions
+
+| Method | Checks |
+|---|---|
+| `assert_entrypoint_registered(name=None, group=None)` | the provider is discoverable under its entry-point group |
+| `assert_routes(signals, context=None)` | `serves(...)` is `True` |
+| `assert_not_routes(signals, context=None)` | `serves(...)` is `False` |
+| `assert_returns_playables(signals, context=None, lang="en-us")` | `search_safe` returns results, each with a truthy `uri`, a `match_confidence` in `[0,1]`, and a `work`; returns the results |
+
+## Exposed attributes
+
+| Attribute | Description |
+|---|---|
+| `provider` | the wrapped provider instance |
+| `api` | the injected mock client (for custom `assert_called_with` checks) |
+| `entrypoint_name` / `entrypoint_group` | set when built via `from_entrypoint` |
+
+## Cross-references
+
+- `MediaProvider` / `QueryContext` — `ovos_plugin_manager.templates.media_provider`
+- `Signals`, `Release`, `MediaType` — `mediavocab`
+- Player-side harness — [media-testing.md](media-testing.md)
+- OCP *search skill* testing (legacy stack) — [ocp.md](ocp.md)

--- a/docs/media-testing.md
+++ b/docs/media-testing.md
@@ -190,6 +190,45 @@ with OCPPlayerHarness() as h:
     # Player auto-advances or stops depending on queue + autoplay config
 ```
 
+### Driving a Real OCP Backend
+
+By default `OCPPlayerHarness` injects a `MockOCPBackend` and mocks out
+`AudioService`, so it exercises the **player state machine** but never the real
+backend routing. To test a **real** OCP audio backend end-to-end — e.g. assert
+that playing a uri makes a Music Assistant backend call its server — pass a
+`backend_factory`: a `bus -> AudioBackend` callable. The harness then wires a
+*real* `AudioService` (no autoload) with your backend as its sole service, so the
+player's `play -> load_track -> LOADED_MEDIA -> backend.play()` path actually
+reaches it.
+
+```python
+from ovoscope.media import OCPPlayerHarness
+from ovos_utils.ocp import MediaEntry, PlaybackType
+
+def make_backend(bus):
+    backend = MAssOCPAudioService(config={"url": "http://mass.local:8095"}, bus=bus)
+    backend.api = mock_client          # mock the network client the backend reaches
+    backend.player_state = {"available": True}
+    return backend
+
+with OCPPlayerHarness(backend_factory=make_backend) as h:
+    h.play(MediaEntry(uri="library://track/42", playback=PlaybackType.AUDIO))
+    h.backend.api.play_media.assert_called_once_with(queue_id, "library://track/42")
+```
+
+Notes:
+
+- The factory **owns mocking** any network client the real backend would reach.
+- Deferred uris (`library://`, `{sei}//…`) are resolved by the OCP pipeline's
+  stream extractors *before* the player in production; the harness loads no
+  extractor plugins, so it bypasses the player's stream validation when a backend
+  factory is used.
+- `name`/`namespace` are supplied by the harness if the backend lacks them
+  (normally set by `BaseMediaService.load_services()`, which the harness bypasses).
+- The mock-only helpers (`assert_backend_paused`, `backend.played_uris`) assume a
+  `MockOCPBackend` and may not apply to a real backend — assert on the backend's
+  own state/spies instead.
+
 ## OCPCaptureSession
 
 `OCPCaptureSession` — `ovoscope/media.py`
@@ -244,6 +283,12 @@ with OCPPlayerHarness() as h:
 ### OCPPlayerHarness
 
 `OCPPlayerHarness` — `ovoscope/media.py`
+
+**Constructor:** `OCPPlayerHarness(backend_namespace="audio", backend_factory=None)`.
+`backend_factory` is an optional `bus -> AudioBackend` callable; when given, the
+harness drives that real backend through a real `AudioService` (see
+[Driving a Real OCP Backend](#driving-a-real-ocp-backend)) instead of the default
+`MockOCPBackend`.
 
 **Control methods** (each emits the corresponding bus message + `time.sleep(0.05)`):
 

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -1113,6 +1113,11 @@ except ImportError as e:
     else:
         raise
 
+# MediaProvider (catalog/search) harness — duck-typed, stdlib-only at import time,
+# so it needs no optional dependency guard (the provider package + mediavocab are
+# only needed by the *test* that uses it, not by ovoscope itself).
+from ovoscope.media_provider import MediaProviderHarness  # noqa: F401,E402
+
 try:
     from ovoscope.tts_intelligibility import (  # noqa: F401
         TTSIntelligibilityHarness,

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -1100,6 +1100,20 @@ except ImportError as e:
         raise
 
 try:
+    from ovoscope.media import (  # noqa: F401
+        MockOCPBackend,
+        OCPPlayerHarness,
+        OCPCaptureSession,
+    )
+except ImportError as e:
+    # Optional [media] extra (ovos-media). Silence only when the missing module
+    # is ovos-media itself; a logic error in a present lib must re-raise.
+    if isinstance(e, ModuleNotFoundError) and e.name in ("ovos_media", "ovos_media.player"):
+        pass
+    else:
+        raise
+
+try:
     from ovoscope.tts_intelligibility import (  # noqa: F401
         TTSIntelligibilityHarness,
         IntelligibilityReport,

--- a/ovoscope/media.py
+++ b/ovoscope/media.py
@@ -26,7 +26,7 @@ Classes:
 
 import dataclasses
 import time
-from typing import List, Optional
+from typing import Callable, List, Optional
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
@@ -268,16 +268,28 @@ class OCPPlayerHarness:
         backend_namespace: Namespace for ``MockOCPBackend``; default ``"audio"``.
     """
 
-    def __init__(self, backend_namespace: str = "audio") -> None:
+    def __init__(self, backend_namespace: str = "audio",
+                 backend_factory: Optional[Callable[[FakeBus], AudioBackend]] = None) -> None:
         """Initialise harness parameters.
 
         Args:
             backend_namespace: Namespace prefix passed to ``MockOCPBackend``.
+            backend_factory: Optional ``bus -> AudioBackend`` callable used to build
+                the injected backend instead of the default :class:`MockOCPBackend`.
+                The harness owns the ``FakeBus``, so a *factory* (not a pre-built
+                instance) is taken: it is called with the harness bus inside
+                ``__enter__``. Use it to drive a **real** OCP backend (e.g. a
+                Music Assistant audio backend) through the real ``OCPMediaPlayer``;
+                the factory is responsible for mocking any network client the real
+                backend would otherwise reach. Note the mock-only assertion helpers
+                (:meth:`assert_backend_paused`, ``backend.played_uris``) assume a
+                :class:`MockOCPBackend` and may not apply to a real backend.
         """
         self.backend_namespace: str = backend_namespace
+        self.backend_factory = backend_factory
         self.bus: Optional[FakeBus] = None
         self.player = None  # OCPMediaPlayer instance
-        self.backend: Optional[MockOCPBackend] = None
+        self.backend: Optional[AudioBackend] = None
         self.gui: Optional[MagicMock] = None
         self._patches: list = []
 
@@ -290,9 +302,19 @@ class OCPPlayerHarness:
         from ovos_media.player import OCPMediaPlayer
 
         self.bus = FakeBus()
-        self.backend = MockOCPBackend(
-            config={}, bus=self.bus, namespace=self.backend_namespace
-        )
+        if self.backend_factory is not None:
+            self.backend = self.backend_factory(self.bus)
+            # A config-loaded backend gets name/namespace from
+            # BaseMediaService.load_services(), which the harness bypasses — supply
+            # sane defaults so the service's bookkeeping (shutdown, routing) works.
+            if not getattr(self.backend, "name", None):
+                self.backend.name = "test-backend"
+            if not getattr(self.backend, "namespace", None):
+                self.backend.namespace = self.backend_namespace
+        else:
+            self.backend = MockOCPBackend(
+                config={}, bus=self.bus, namespace=self.backend_namespace
+            )
 
         # Build patch targets
         gui_mock = MagicMock()
@@ -341,22 +363,50 @@ class OCPPlayerHarness:
         # Instantiate the real player (all heavy deps are now mocked)
         self.player = OCPMediaPlayer(self.bus, config={})
 
-        # Inject MockOCPBackend as the sole audio backend
-        audio_svc = self.player.audio_service
-        audio_svc.services = [self.backend]
-        audio_svc.default = self.backend
-        self.backend.set_track_start_callback(audio_svc.track_start)
-
-        # Register the audio service bus handlers manually
-        # (normally done inside BaseMediaService.load_services)
         ns = self.backend_namespace
-        self.bus.on(f"ovos.{ns}.service.play", audio_svc.handle_play)
-        self.bus.on(f"ovos.{ns}.service.pause", audio_svc.pause)
-        self.bus.on(f"ovos.{ns}.service.resume", audio_svc.resume)
-        self.bus.on(f"ovos.{ns}.service.stop", audio_svc.stop)
-        self.bus.on("ovos.common_play.media.state",
-                    audio_svc.handle_media_state_change)
-        audio_svc._loaded.set()
+        if self.backend_factory is not None:
+            # Real-backend mode: the mocked AudioService (a MagicMock) never routes
+            # play()->load_track()->backend.play(), so swap in a *real* AudioService
+            # with autoload off and the injected backend as its sole service. Now the
+            # player's playback path actually drives the real backend (e.g. asserting
+            # a Music Assistant client's play_media() call).
+            from ovos_media.media_backends.audio import AudioService as _RealAudioService
+            audio_svc = _RealAudioService(self.bus, config={"audio_players": {}},
+                                          autoload=False, validate_source=False)
+            self.player.audio_service = audio_svc
+            # Deferred uris (e.g. library://, {sei}//) are resolved by the OCP
+            # pipeline's stream extractors *before* the player sees them; this
+            # harness drives the backend directly, so bypass the player's
+            # stream-extraction validation (no extractor plugins are loaded).
+            self.player.validate_stream = lambda: True
+            audio_svc.services = [self.backend]
+            audio_svc.default = self.backend
+            self.backend.set_track_start_callback(audio_svc.track_start)
+            # load_services() (skipped with autoload=False) would register these.
+            self.bus.on(f"ovos.{ns}.service.play", audio_svc.handle_play)
+            self.bus.on(f"ovos.{ns}.service.pause", audio_svc.pause)
+            self.bus.on(f"ovos.{ns}.service.resume", audio_svc.resume)
+            self.bus.on(f"ovos.{ns}.service.stop", audio_svc.stop)
+            # NB: BaseMediaService.__init__ already wired ovos.common_play.media.state
+            # -> handle_media_state_change; re-registering it would fire backend.play()
+            # twice, so it is deliberately omitted here.
+            audio_svc._loaded.set()
+        else:
+            # Mock-backend mode: drive the player state-machine against the MagicMock
+            # AudioService; the backend is exposed for manual simulate_*/state asserts.
+            audio_svc = self.player.audio_service
+            audio_svc.services = [self.backend]
+            audio_svc.default = self.backend
+            self.backend.set_track_start_callback(audio_svc.track_start)
+            # Register the audio service bus handlers manually
+            # (normally done inside BaseMediaService.load_services)
+            self.bus.on(f"ovos.{ns}.service.play", audio_svc.handle_play)
+            self.bus.on(f"ovos.{ns}.service.pause", audio_svc.pause)
+            self.bus.on(f"ovos.{ns}.service.resume", audio_svc.resume)
+            self.bus.on(f"ovos.{ns}.service.stop", audio_svc.stop)
+            self.bus.on("ovos.common_play.media.state",
+                        audio_svc.handle_media_state_change)
+            audio_svc._loaded.set()
 
         return self
 

--- a/ovoscope/media_provider.py
+++ b/ovoscope/media_provider.py
@@ -1,0 +1,194 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MediaProvider (catalog/search) test harness for ovoscope.
+
+``ovoscope.media`` drives the OCP *player* state-machine; this module is its
+catalog/search counterpart — a harness for ``opm.media.provider`` plugins
+(``MediaProvider`` subclasses introduced by the ovos-media sprint).
+
+There is no released loader for the ``opm.media.provider`` entry-point group, and
+the OCP pipeline does not yet load providers in-process, so this harness models
+the pipeline's *intended* path:
+
+    discover the provider  ->  gate it with ``serves(signals, context)``
+                           ->  call the never-raising ``search_safe``
+
+It is deliberately **duck-typed**: it imports neither mediavocab (``Signals`` /
+``Release``) nor ovos-plugin-manager's ``MediaProvider`` / ``QueryContext``. The
+test supplies whatever ``signals`` / ``context`` objects the provider expects, so
+ovoscope stays dependency-free and usable even without the (currently branch-only)
+``opm.media.provider`` plugin type installed.
+
+Usage::
+
+    from ovoscope import MediaProviderHarness
+
+    h = MediaProviderHarness.from_entrypoint(
+        "music_assistant",
+        config={"url": "http://mass.local:8095"},
+        mock_api=my_mock_client,            # injected onto provider._api
+    )
+    h.assert_entrypoint_registered()
+    h.assert_routes(Signals(medium=MediaType.MUSIC),
+                    QueryContext(supported_playback_types={"audio"}))
+    h.assert_not_routes(Signals(medium=MediaType.MOVIE))
+    releases = h.assert_returns_playables(Signals(title="worms"))
+"""
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+from typing import Any, List, Optional
+
+DEFAULT_GROUP = "opm.media.provider"
+
+
+class MediaProviderHarness:
+    """Wrap a ``MediaProvider`` instance and drive it the way the OCP pipeline does.
+
+    Build one with :meth:`from_entrypoint` (real plugin discovery) or
+    :meth:`from_class` (a class you already hold — used by ovoscope's own tests).
+    The wrapped instance is exposed as :attr:`provider` and the injected mock
+    client as :attr:`api` for custom assertions.
+    """
+
+    def __init__(self, provider: Any, api: Any = None,
+                 entrypoint_name: Optional[str] = None,
+                 entrypoint_group: str = DEFAULT_GROUP) -> None:
+        self.provider = provider
+        self.api = api
+        self.entrypoint_name = entrypoint_name
+        self.entrypoint_group = entrypoint_group
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_class(cls, provider_cls: Any, config: Optional[dict] = None,
+                   mock_api: Any = None, api_attr: str = "_api") -> "MediaProviderHarness":
+        """Instantiate ``provider_cls(config)`` and (optionally) inject ``mock_api``.
+
+        Args:
+            provider_cls: a ``MediaProvider`` subclass (duck-typed — anything with
+                ``is_available`` / ``serves`` / ``search`` / ``search_safe`` /
+                ``featured_media``).
+            config: config dict passed to the provider constructor.
+            mock_api: object set onto ``provider.<api_attr>`` to bypass the real
+                (network) client built lazily by the provider.
+            api_attr: attribute name the provider reads its client from
+                (default ``"_api"``).
+        """
+        provider = provider_cls(config or {})
+        if mock_api is not None:
+            setattr(provider, api_attr, mock_api)
+        return cls(provider, api=mock_api)
+
+    @classmethod
+    def from_entrypoint(cls, name: str, config: Optional[dict] = None,
+                        group: str = DEFAULT_GROUP, mock_api: Any = None,
+                        api_attr: str = "_api") -> "MediaProviderHarness":
+        """Discover the provider through its installed entry-point and wrap it.
+
+        Resolves ``name`` in the ``group`` entry-point group (default
+        ``opm.media.provider``), loads the class, and delegates to
+        :meth:`from_class`. Raises ``AssertionError`` if the entry-point is not
+        installed (or is ambiguous) — that *is* the e2e signal that the plugin's
+        packaging registered it correctly.
+        """
+        matches = [ep for ep in entry_points(group=group) if ep.name == name]
+        if not matches:
+            raise AssertionError(
+                f"no {group!r} entry-point named {name!r} is installed — "
+                f"is the provider package installed (pip install -e .)?"
+            )
+        if len(matches) > 1:
+            raise AssertionError(
+                f"multiple {group!r} entry-points named {name!r}: {matches!r}"
+            )
+        provider_cls = matches[0].load()
+        harness = cls.from_class(provider_cls, config=config,
+                                 mock_api=mock_api, api_attr=api_attr)
+        harness.entrypoint_name = name
+        harness.entrypoint_group = group
+        return harness
+
+    # ------------------------------------------------------------------
+    # Drivers — mirror the pipeline's discover -> gate -> search path
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Provider self-check (server reachable / keys present)."""
+        return self.provider.is_available()
+
+    def serves(self, signals: Any, context: Any = None) -> bool:
+        """Context-aware routing gate (three-axis ``matches`` + device/policy)."""
+        return self.provider.serves(signals, context)
+
+    def search(self, signals: Any, lang: str = "en-us") -> List[Any]:
+        """Raw search — may raise, mirroring a direct provider call."""
+        return self.provider.search(signals, lang=lang)
+
+    def search_safe(self, signals: Any, context: Any = None,
+                    lang: str = "en-us") -> List[Any]:
+        """The never-raising entry the pipeline's thread-pool dispatch calls."""
+        return self.provider.search_safe(signals, context=context, lang=lang)
+
+    def featured_media(self, lang: str = "en-us") -> List[Any]:
+        """Curated/home content (recently-played, recommendations, …)."""
+        return self.provider.featured_media(lang=lang)
+
+    # ------------------------------------------------------------------
+    # Assertions
+    # ------------------------------------------------------------------
+
+    def assert_entrypoint_registered(self, name: Optional[str] = None,
+                                     group: Optional[str] = None) -> None:
+        """Assert the provider is discoverable under its entry-point group."""
+        name = name or self.entrypoint_name
+        group = group or self.entrypoint_group
+        assert name, ("no entry-point name to check — pass name=, or build the "
+                      "harness with from_entrypoint()")
+        names = [ep.name for ep in entry_points(group=group)]
+        assert name in names, (
+            f"{name!r} is not registered under {group!r}; found {names!r}"
+        )
+
+    def assert_routes(self, signals: Any, context: Any = None) -> None:
+        """Assert the provider serves ``signals`` under ``context``."""
+        assert self.serves(signals, context), (
+            f"provider does not serve {signals!r} (context={context!r})"
+        )
+
+    def assert_not_routes(self, signals: Any, context: Any = None) -> None:
+        """Assert the provider is gated out for ``signals`` under ``context``."""
+        assert not self.serves(signals, context), (
+            f"provider unexpectedly serves {signals!r} (context={context!r})"
+        )
+
+    def assert_returns_playables(self, signals: Any, context: Any = None,
+                                 lang: str = "en-us") -> List[Any]:
+        """Assert ``search_safe`` returns ranked, playable results and return them.
+
+        Each result must carry a truthy ``uri``, a ``match_confidence`` in
+        ``[0.0, 1.0]``, and a ``work``.
+        """
+        results = self.search_safe(signals, context=context, lang=lang)
+        assert results, f"provider returned no results for {signals!r}"
+        for r in results:
+            assert getattr(r, "uri", None), f"result has no uri: {r!r}"
+            mc = getattr(r, "match_confidence", None)
+            assert mc is not None and 0.0 <= mc <= 1.0, (
+                f"result match_confidence out of [0,1]: {mc!r} ({r!r})"
+            )
+            assert getattr(r, "work", None) is not None, f"result has no work: {r!r}"
+        return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ classifiers = [
 [project.optional-dependencies]
 pydantic = ["ovos-pydantic-models>=0.1.0"]
 audio = ["ovos-audio>=1.2.0"]
+# OCP / ovos-media player harnesses (ovoscope.media: OCPPlayerHarness, ...).
+media = ["ovos-media>=0.0.2a3"]
 # End-to-end TTS intelligibility scoring (WER/CER round-trip via reference STT).
 # faster-whisper itself is pulled by the plugin — don't list it here to avoid
 # version skew.
@@ -43,6 +45,7 @@ tts = [
 ]
 dev = [
     "ovos-audio>=1.2.0",
+    "ovos-media>=0.0.2a3",
     "ovos-pydantic-models>=0.1.0",
     "jiwer",
     "ovos-utterance-normalizer",

--- a/test/unittests/test_media.py
+++ b/test/unittests/test_media.py
@@ -20,7 +20,17 @@ from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.ocp import MediaState
 
-from ovoscope.media import MockOCPBackend, OCPCaptureSession
+from ovoscope.media import MockOCPBackend, OCPCaptureSession, OCPPlayerHarness
+
+
+def test_media_harness_reexported_from_package() -> None:
+    """The ovos-media harness is reachable from the top-level package, like the
+    ovos-audio harness. (media.py imports ovos-media lazily, so the export does
+    not require the [media] extra to be installed.)"""
+    import ovoscope
+    assert ovoscope.OCPPlayerHarness is OCPPlayerHarness
+    assert ovoscope.OCPCaptureSession is OCPCaptureSession
+    assert ovoscope.MockOCPBackend is MockOCPBackend
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_media.py
+++ b/test/unittests/test_media.py
@@ -212,3 +212,87 @@ class TestOCPCaptureSessionMessageAccumulation:
         self.bus.emit(Message("ovos.common_play.play"))  # should not be captured
         session.stop()
         assert session.message_types == ["custom.prefix.event"]
+
+
+try:
+    import ovos_media  # noqa: F401
+    _HAS_OVOS_MEDIA = True
+except ImportError:
+    _HAS_OVOS_MEDIA = False
+
+
+if _HAS_OVOS_MEDIA:
+    from ovos_plugin_manager.templates.media import AudioPlayerBackend
+
+    class _RecordingBackend(AudioPlayerBackend):
+        """A real OCP ``MediaBackend`` stand-in built by a factory.
+
+        Subclasses the genuine ``AudioPlayerBackend`` (not ``MockOCPBackend``) so
+        its ``load_track`` emits the real ``ovos.common_play.media.state``
+        ``LOADED_MEDIA`` event the live ``AudioService`` routes on. Records the uri
+        its ``play()`` is driven with — analogous to a Music Assistant backend
+        calling ``client.play_media(uri)`` — so a test can assert the player's play
+        path actually reached the injected backend.
+        """
+
+        def __init__(self, bus):
+            super().__init__(config={}, bus=bus)
+            self.play_calls = []
+            self.is_playing = False
+
+        def supported_uris(self):
+            return ["library", "http", "https"]
+
+        def play(self, repeat: bool = False):
+            self.is_playing = True
+            self.play_calls.append(self._now_playing)
+
+        def stop(self):
+            self.is_playing = False
+            return True
+
+        def pause(self):
+            pass
+
+        def resume(self):
+            pass
+
+        def lower_volume(self):
+            pass
+
+        def restore_volume(self):
+            pass
+
+        def get_track_length(self):
+            return 0
+
+        def get_track_position(self):
+            return 0
+
+        def set_track_position(self, milliseconds):
+            pass
+
+
+@pytest.mark.skipif(not _HAS_OVOS_MEDIA,
+                    reason="requires the [media] extra (ovos-media)")
+class TestOCPPlayerHarnessBackendInjection:
+    """OCPPlayerHarness(backend_factory=...) drives a real injected backend."""
+
+    def test_default_factory_is_mock_backend(self) -> None:
+        with OCPPlayerHarness() as h:
+            assert isinstance(h.backend, MockOCPBackend)
+            assert type(h.backend) is MockOCPBackend
+
+    def test_injected_backend_is_used(self) -> None:
+        with OCPPlayerHarness(backend_factory=_RecordingBackend) as h:
+            assert isinstance(h.backend, _RecordingBackend)
+            # name is supplied by the harness when the backend lacks one
+            assert getattr(h.backend, "name", None)
+
+    def test_player_drives_injected_backend_play(self) -> None:
+        from ovos_utils.ocp import MediaEntry, PlaybackType
+        with OCPPlayerHarness(backend_factory=_RecordingBackend) as h:
+            h.play(MediaEntry(uri="library://track/42",
+                              playback=PlaybackType.AUDIO))
+            assert h.backend.is_playing is True
+            assert h.backend.play_calls == ["library://track/42"]

--- a/test/unittests/test_media_provider.py
+++ b/test/unittests/test_media_provider.py
@@ -1,0 +1,217 @@
+"""Tests for ovoscope.media_provider.MediaProviderHarness.
+
+The harness is duck-typed, so these tests use a dependency-free ``_DummyProvider``
+(no mediavocab / ovos-plugin-manager import) and ``SimpleNamespace`` stand-ins for
+``Signals`` / ``QueryContext`` / ``Release``.
+"""
+import types
+
+import pytest
+
+from ovoscope import MediaProviderHarness
+from ovoscope.media_provider import DEFAULT_GROUP
+
+
+# --------------------------------------------------------------------------
+# duck-typed fixtures (no real mediavocab / opm types)
+# --------------------------------------------------------------------------
+
+def _signals(title="x", medium="music", artist=None):
+    return types.SimpleNamespace(title=title, medium=medium, artist=artist)
+
+
+def _context(supported_playback_types=None, blocked_genres=None):
+    return types.SimpleNamespace(
+        supported_playback_types=supported_playback_types or set(),
+        blocked_genres=blocked_genres or set(),
+    )
+
+
+def _release(uri, title="T", mc=0.5):
+    return types.SimpleNamespace(
+        uri=uri, match_confidence=mc,
+        work=types.SimpleNamespace(title=title),
+    )
+
+
+class _DummyProvider:
+    """Minimal MediaProvider look-alike: serves music, returns library:// uris."""
+
+    name = "dummy"
+
+    def __init__(self, config=None):
+        self.config = config or {}
+        self._api = None
+        self._served = {"music", "radio"}
+
+    def is_available(self):
+        return self._api is not None
+
+    def serves(self, signals, context=None):
+        if getattr(signals, "medium", None) not in self._served:
+            return False
+        if context is not None:
+            spt = getattr(context, "supported_playback_types", set())
+            if spt and "audio" not in spt:
+                return False
+        return True
+
+    def search(self, signals, lang="en-us"):
+        if self._api is None:
+            return []
+        return [_release("library://track/1", "Hit", 0.9),
+                _release("library://track/2", "Miss", 0.3)]
+
+    def search_safe(self, signals, context=None, lang="en-us"):
+        try:
+            return self.search(signals, lang=lang)
+        except Exception:
+            return []
+
+    def featured_media(self, lang="en-us"):
+        return [_release("library://track/3", "Featured", 0.0)]
+
+
+class _ExplodingProvider(_DummyProvider):
+    def search(self, signals, lang="en-us"):
+        raise RuntimeError("backend exploded")
+
+
+def _harness(mock_api="client", provider_cls=_DummyProvider):
+    return MediaProviderHarness.from_class(
+        provider_cls, config={"url": "http://x"}, mock_api=mock_api)
+
+
+# --------------------------------------------------------------------------
+# from_class + injection
+# --------------------------------------------------------------------------
+
+def test_from_class_instantiates_and_injects_api():
+    sentinel = object()
+    h = _harness(mock_api=sentinel)
+    assert isinstance(h.provider, _DummyProvider)
+    assert h.provider._api is sentinel
+    assert h.api is sentinel
+    assert h.provider.config == {"url": "http://x"}
+
+
+def test_from_class_custom_api_attr():
+    sentinel = object()
+    h = MediaProviderHarness.from_class(_DummyProvider, mock_api=sentinel,
+                                        api_attr="config")
+    assert h.provider.config is sentinel
+
+
+def test_is_available_reflects_injected_client():
+    assert _harness(mock_api="client").is_available() is True
+    assert MediaProviderHarness.from_class(_DummyProvider).is_available() is False
+
+
+# --------------------------------------------------------------------------
+# routing / serves drivers + asserts
+# --------------------------------------------------------------------------
+
+def test_serves_and_assert_routes():
+    h = _harness()
+    assert h.serves(_signals(medium="music")) is True
+    h.assert_routes(_signals(medium="music"))
+    h.assert_routes(_signals(medium="music"),
+                    _context(supported_playback_types={"audio"}))
+
+
+def test_assert_not_routes_unserved_medium():
+    h = _harness()
+    assert h.serves(_signals(medium="movie")) is False
+    h.assert_not_routes(_signals(medium="movie"))
+
+
+def test_assert_not_routes_video_only_device():
+    h = _harness()
+    h.assert_not_routes(_signals(medium="music"),
+                        _context(supported_playback_types={"video"}))
+
+
+def test_assert_routes_raises_when_not_served():
+    h = _harness()
+    with pytest.raises(AssertionError):
+        h.assert_routes(_signals(medium="movie"))
+
+
+# --------------------------------------------------------------------------
+# search / search_safe drivers + playable asserts
+# --------------------------------------------------------------------------
+
+def test_search_safe_returns_playables():
+    h = _harness()
+    results = h.assert_returns_playables(_signals())
+    assert [r.work.title for r in results] == ["Hit", "Miss"]
+    assert all(r.uri.startswith("library://") for r in results)
+
+
+def test_search_safe_swallows_backend_error():
+    h = _harness(provider_cls=_ExplodingProvider)
+    assert h.search_safe(_signals()) == []
+
+
+def test_assert_returns_playables_fails_on_empty():
+    h = MediaProviderHarness.from_class(_DummyProvider)  # no api -> search returns []
+    with pytest.raises(AssertionError):
+        h.assert_returns_playables(_signals())
+
+
+def test_assert_returns_playables_fails_on_bad_confidence():
+    class _BadProvider(_DummyProvider):
+        def search(self, signals, lang="en-us"):
+            return [_release("library://track/9", "Bad", mc=5.0)]  # out of [0,1]
+
+    h = _harness(provider_cls=_BadProvider)
+    with pytest.raises(AssertionError):
+        h.assert_returns_playables(_signals())
+
+
+def test_featured_media():
+    h = _harness()
+    feats = h.featured_media()
+    assert [r.work.title for r in feats] == ["Featured"]
+
+
+# --------------------------------------------------------------------------
+# from_entrypoint (monkeypatched discovery)
+# --------------------------------------------------------------------------
+
+def _fake_entry_points(monkeypatch, eps):
+    monkeypatch.setattr("ovoscope.media_provider.entry_points",
+                        lambda group=None: eps)
+
+
+def test_from_entrypoint_discovers_and_loads(monkeypatch):
+    ep = types.SimpleNamespace(name="dummy", load=lambda: _DummyProvider)
+    _fake_entry_points(monkeypatch, [ep])
+
+    h = MediaProviderHarness.from_entrypoint("dummy", config={"url": "u"},
+                                             mock_api="client")
+    assert isinstance(h.provider, _DummyProvider)
+    assert h.provider._api == "client"
+    assert h.entrypoint_name == "dummy"
+    assert h.entrypoint_group == DEFAULT_GROUP
+    h.assert_entrypoint_registered()  # "dummy" present in the patched group
+
+
+def test_from_entrypoint_missing_raises(monkeypatch):
+    _fake_entry_points(monkeypatch, [])
+    with pytest.raises(AssertionError):
+        MediaProviderHarness.from_entrypoint("nope")
+
+
+def test_from_entrypoint_ambiguous_raises(monkeypatch):
+    ep1 = types.SimpleNamespace(name="dummy", load=lambda: _DummyProvider)
+    ep2 = types.SimpleNamespace(name="dummy", load=lambda: _DummyProvider)
+    _fake_entry_points(monkeypatch, [ep1, ep2])
+    with pytest.raises(AssertionError):
+        MediaProviderHarness.from_entrypoint("dummy")
+
+
+def test_assert_entrypoint_registered_without_name_raises():
+    h = MediaProviderHarness.from_class(_DummyProvider)  # no entrypoint name
+    with pytest.raises(AssertionError):
+        h.assert_entrypoint_registered()


### PR DESCRIPTION
## What

`ovoscope.media` already provides an ovos-media testing harness — `OCPPlayerHarness` (wires a real `OCPMediaPlayer` onto a `FakeBus`), `OCPCaptureSession`, and `MockOCPBackend` — but unlike the ovos-audio `AudioServiceHarness`, it is **not** re-exported from the top-level package and has **no** matching extra.

This wires it up symmetrically with the audio harness:

- Re-export `OCPPlayerHarness`, `OCPCaptureSession`, `MockOCPBackend` from `ovoscope/__init__.py`, guarded the same way as the `ovoscope.audio` block.
- Add a `media = ["ovos-media>=0.0.2a3"]` optional-dependency extra (and add `ovos-media` to `dev`).

## Why

While writing ovoscope end-to-end tests for an OCP audio backend plugin, the only documented entry point was `AudioServiceHarness` — which targets the **legacy ovos-audio** stack (`AudioBackend`: `name`, `clear_list`, …). An OCP `MediaBackend` cannot be driven through it. The harness for ovos-media existed in `media.py` but wasn't discoverable via `from ovoscope import ...`, and its `ovos-media` dependency wasn't declared anywhere.

## Notes

- `media.py` imports `ovos_media` **lazily** (inside `OCPPlayerHarness.__enter__`), so the top-level export needs no extra at import time; the `[media]` extra is required only to actually run the harness. Importing `ovoscope` without ovos-media installed still works.
- Added a regression test asserting the re-export resolves to the same objects as `ovoscope.media`.

## Test

`test/unittests/test_media.py` passes (26, incl. the new export test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media harness functionality is now available as an optional feature, including player and capture session components.

* **Chores**
  * Added optional `media` dependency support for enhanced functionality. Install via the `media` extra or include in development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->