### PR TITLE
feat!: audio harness on OVOS spec bus namespace

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -301,7 +301,19 @@ class MiniCroft(SkillManager):
                  lang: Optional[str] = None,
                  secondary_langs: Optional[List[str]] = None,
                  pipeline_config: Optional[Dict[str, Dict]] = None,
+                 modernize: bool = True,
+                 emit_legacy: bool = True,
                  *args, **kwargs):
+        # Namespace-migration flags forwarded to the harness FakeBus so callers
+        # can choose which bus namespace(s) to exercise:
+        #   modernize=True   emitting a legacy topic ALSO emits the ovos.* spec
+        #                    topic (legacy producer -> spec listener)
+        #   emit_legacy=True emitting an ovos.* spec topic ALSO emits the legacy
+        #                    topic (spec producer -> legacy listener)
+        # Both default on (mirrors MessageBusClient). Set BOTH False to isolate a
+        # single namespace and assert no cross-namespace bridging occurs.
+        self._modernize = modernize
+        self._emit_legacy = emit_legacy
         self._isolated_config = isolate_config
         self._original_xdg_configs: Optional[List[LocalConf]] = None
 
@@ -376,7 +388,8 @@ class MiniCroft(SkillManager):
                 LOG.debug(f"ovoscope: pipeline_config patched '{plugin_key}'")
 
         self.boot_messages: List[Message] = []
-        bus = FakeBus()
+        bus = FakeBus(modernize=self._modernize,
+                      emit_legacy=self._emit_legacy)
         bus.on("message", self.handle_boot_message)
         self.skill_ids = skill_ids
         self.extra_skills = extra_skills or {}

--- a/ovoscope/audio.py
+++ b/ovoscope/audio.py
@@ -33,6 +33,7 @@ from typing import ClassVar, Dict, Generator, List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_plugin_manager.templates.audio import AudioBackend
 from ovos_plugin_manager.templates.tts import TTS
 from ovos_utils.fakebus import FakeBus
@@ -282,9 +283,9 @@ class AudioServiceHarness:
                     self.service._get_track_length)
         self.bus.on("mycroft.audio.service.seek_forward", self.service._seek_forward)
         self.bus.on("mycroft.audio.service.seek_backward", self.service._seek_backward)
-        self.bus.on("recognizer_loop:audio_output_start",
+        self.bus.on(SpecMessage.AUDIO_OUTPUT_STARTED,
                     self.service._lower_volume_on_speak)
-        self.bus.on("recognizer_loop:audio_output_end",
+        self.bus.on(SpecMessage.AUDIO_OUTPUT_ENDED,
                     self.service._restore_volume_on_speak)
         self.bus.on("recognizer_loop:record_begin",
                     self.service._lower_volume_on_record)
@@ -508,8 +509,8 @@ class PlaybackServiceHarness:
     """Context manager wrapping PlaybackService with a MockTTS on a FakeBus.
 
     PlaybackService is a ``Thread``; this harness starts it and wires it to the
-    provided FakeBus so tests can emit ``speak`` messages and observe the
-    resulting ``recognizer_loop:audio_output_start/end`` events.
+    provided FakeBus so tests can emit ``ovos.utterance.speak`` messages and
+    observe the resulting ``ovos.audio.output.started/ended`` events.
 
     The harness patches ``ovos_utils.sound.play_audio`` so no actual audio
     device is accessed. It also drains ``TTS.queue`` before construction to
@@ -603,11 +604,11 @@ class PlaybackServiceHarness:
             self.mock_tts.init(self.bus, self.svc.playback_thread)
 
             # Subscribe lifecycle events for synchronisation
-            self.bus.on("recognizer_loop:audio_output_start",
+            self.bus.on(SpecMessage.AUDIO_OUTPUT_STARTED,
                         lambda m: self._audio_output_start.set())
-            self.bus.on("recognizer_loop:audio_output_end",
+            self.bus.on(SpecMessage.AUDIO_OUTPUT_ENDED,
                         lambda m: self._audio_output_end.set())
-            self.bus.on("mycroft.mic.listen",
+            self.bus.on(SpecMessage.MIC_LISTEN,
                         lambda m: self._mic_listen.set())
 
         except Exception:
@@ -660,7 +661,7 @@ class PlaybackServiceHarness:
         self._audio_output_end.clear()
         self._mic_listen.clear()
 
-        self.bus.emit(Message("speak", {
+        self.bus.emit(Message(SpecMessage.SPEAK, {
             "utterance": utterance,
             "lang": "en-US",
             "expect_response": expect_response,
@@ -692,31 +693,31 @@ class PlaybackServiceHarness:
         )
 
     def assert_audio_output_started(self, timeout: float = 3.0) -> None:
-        """Assert that recognizer_loop:audio_output_start was emitted.
+        """Assert that ovos.audio.output.started was emitted.
 
         Args:
             timeout: Seconds to wait for the event.
         """
         assert self._audio_output_start.wait(timeout), \
-            "recognizer_loop:audio_output_start was not emitted"
+            "ovos.audio.output.started was not emitted"
 
     def assert_audio_output_ended(self, timeout: float = 3.0) -> None:
-        """Assert that recognizer_loop:audio_output_end was emitted.
+        """Assert that ovos.audio.output.ended was emitted.
 
         Args:
             timeout: Seconds to wait for the event.
         """
         assert self._audio_output_end.wait(timeout), \
-            "recognizer_loop:audio_output_end was not emitted"
+            "ovos.audio.output.ended was not emitted"
 
     def assert_mic_listen(self, timeout: float = 3.0) -> None:
-        """Assert that mycroft.mic.listen was emitted after speech.
+        """Assert that ovos.mic.listen was emitted after speech.
 
         Args:
             timeout: Seconds to wait for the event.
         """
         assert self._mic_listen.wait(timeout), \
-            "mycroft.mic.listen was not emitted"
+            "ovos.mic.listen was not emitted"
 
 
 # ---------------------------------------------------------------------------
@@ -742,8 +743,8 @@ class AudioCaptureSession:
     bus: FakeBus
     track_prefixes: List[str] = dataclasses.field(default_factory=lambda: [
         "mycroft.audio.",
-        "recognizer_loop:audio_output",
-        "mycroft.mic.listen",
+        "ovos.audio.output",
+        "ovos.mic.listen",
     ])
     messages: List[Message] = dataclasses.field(default_factory=list)
 

--- a/ovoscope/audio.py
+++ b/ovoscope/audio.py
@@ -228,17 +228,28 @@ class AudioServiceHarness:
 
     def __init__(self, backend_name: str = "mock",
                  validate_source: bool = False,
-                 disable_ocp: bool = True) -> None:
+                 disable_ocp: bool = True,
+                 modernize: bool = True,
+                 emit_legacy: bool = True) -> None:
         """Initialise harness parameters.
 
         Args:
             backend_name: Name for the MockAudioBackend instance.
             validate_source: Enable source-session validation in AudioService.
             disable_ocp: Disable OCP plugin during tests.
+            modernize: FakeBus also emits the ovos.* spec topic when a legacy
+                topic is emitted (legacy producer -> spec listener). ovos-audio
+                emits legacy audio_output_start/end; the harness subscribes on
+                the spec topics, so this bridge is what connects them.
+            emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec
+                topic is emitted (spec producer -> legacy listener). Set both
+                False to exercise a single namespace with no bridging.
         """
         self.backend_name: str = backend_name
         self.validate_source: bool = validate_source
         self.disable_ocp: bool = disable_ocp
+        self.modernize: bool = modernize
+        self.emit_legacy: bool = emit_legacy
         self.bus: Optional[FakeBus] = None
         self.service = None  # AudioService instance
         self.backend: Optional[MockAudioBackend] = None
@@ -251,7 +262,8 @@ class AudioServiceHarness:
         """
         from ovos_audio.audio import AudioService
 
-        self.bus = FakeBus()
+        self.bus = FakeBus(modernize=self.modernize,
+                           emit_legacy=self.emit_legacy)
         self.backend = MockAudioBackend(config={}, bus=self.bus,
                                         name=self.backend_name)
 
@@ -527,16 +539,27 @@ class PlaybackServiceHarness:
 
     def __init__(self, validate_source: bool = False,
                  disable_ocp: bool = True,
-                 tts: Optional[TTS] = None) -> None:
+                 tts: Optional[TTS] = None,
+                 modernize: bool = True,
+                 emit_legacy: bool = True) -> None:
         """Initialise harness parameters.
 
         Args:
             validate_source: Enable session-source validation.
             disable_ocp: Disable OCP audio plugin.
             tts: TTS instance to inject. Defaults to ``MockTTS()`` when None.
+            modernize: FakeBus also emits the ovos.* spec topic when a legacy
+                topic is emitted (legacy producer -> spec listener). PlaybackService
+                emits legacy audio_output_start/end and mic.listen; the harness
+                subscribes on the spec topics, so this bridge connects them.
+            emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec
+                topic is emitted (spec producer -> legacy listener). Set both
+                False to exercise a single namespace with no bridging.
         """
         self.validate_source: bool = validate_source
         self.disable_ocp: bool = disable_ocp
+        self.modernize: bool = modernize
+        self.emit_legacy: bool = emit_legacy
         self.bus: Optional[FakeBus] = None
         self.svc = None  # PlaybackService instance
         # ``mock_tts`` keeps its historic name for backward compatibility but
@@ -569,7 +592,8 @@ class PlaybackServiceHarness:
                     break
         TTS.queue = Queue()
 
-        self.bus = FakeBus()
+        self.bus = FakeBus(modernize=self.modernize,
+                           emit_legacy=self.emit_legacy)
         # Inject the provided TTS (real plugin) or fall back to MockTTS.
         self.mock_tts = self.tts if self.tts is not None else MockTTS()
 
@@ -741,10 +765,19 @@ class AudioCaptureSession:
     """
 
     bus: FakeBus
+    # capture BOTH the legacy and the ovos.* spec topics of the migrating audio
+    # messages. The capture session observes the raw "message" wire stream, which
+    # carries the producer's ORIGINAL topic only (FakeBus' namespace bridging
+    # re-dispatches the counterpart as a typed event, not a second "message"
+    # event). Listing both namespaces lets the session record the sequence
+    # whether the producer emits legacy or spec, so harness users can assert on
+    # either namespace.
     track_prefixes: List[str] = dataclasses.field(default_factory=lambda: [
         "mycroft.audio.",
         "ovos.audio.output",
+        "recognizer_loop:audio_output",
         "ovos.mic.listen",
+        "mycroft.mic.listen",
     ])
     messages: List[Message] = dataclasses.field(default_factory=list)
 

--- a/ovoscope/classic_listener.py
+++ b/ovoscope/classic_listener.py
@@ -297,7 +297,14 @@ class MiniClassicListener(ListenerHarness):
             :class:`MockHotWordEngine`).
         stt_instance: STT engine for the built loop (defaults to
             :class:`MockStreamingSTT`).
-        bus: Optional :class:`FakeBus` to capture on.
+        bus: Optional :class:`FakeBus` to capture on.  When ``None`` a fresh
+            :class:`FakeBus` is built using *modernize* / *emit_legacy*.
+        modernize: When a fresh bus is built, have :class:`FakeBus` also emit the
+            ovos.* spec topic whenever a legacy topic is emitted (legacy ->
+            spec bridging).  Ignored when *bus* is supplied.  Defaults to True.
+        emit_legacy: When a fresh bus is built, have :class:`FakeBus` also emit
+            the legacy topic whenever an ovos.* spec topic is emitted (spec ->
+            legacy bridging).  Ignored when *bus* is supplied.  Defaults to True.
 
     Raises:
         RuntimeError: If *recognizer_loop* is ``None`` and
@@ -311,7 +318,13 @@ class MiniClassicListener(ListenerHarness):
         wakeword: Optional[Any] = None,
         stt_instance: Optional[Any] = None,
         bus: Optional[FakeBus] = None,
+        modernize: bool = True,
+        emit_legacy: bool = True,
     ) -> None:
+        if bus is None:
+            bus = FakeBus(modernize=modernize, emit_legacy=emit_legacy)
+        self.modernize: bool = modernize
+        self.emit_legacy: bool = emit_legacy
         super().__init__(bus)
         self._built = recognizer_loop is None
         self._wakeword = wakeword

--- a/ovoscope/e2e.py
+++ b/ovoscope/e2e.py
@@ -228,6 +228,13 @@ class E2EPipelineHarness(unittest.TestCase):
     SKILL_ID: ClassVar[str] = "test_skill_ovoscope"
     DEFAULT_LANG: ClassVar[str] = "en-US"
     STARTUP_MAX_WAIT: ClassVar[float] = 60.0
+    # Namespace-migration flags forwarded to the harness MiniCroft / FakeBus.
+    # MODERNIZE on: a legacy emit (recognizer_loop:utterance) also dispatches its
+    # ovos.* spec counterpart (ovos.utterance.handle); EMIT_LEGACY on: a spec emit
+    # also dispatches the legacy topic. Both default on. Subclasses set BOTH False
+    # to drive a single isolated namespace.
+    MODERNIZE: ClassVar[bool] = True
+    EMIT_LEGACY: ClassVar[bool] = True
 
     mc: ClassVar[Any]
     pipeline: ClassVar[Any]
@@ -252,6 +259,8 @@ class E2EPipelineHarness(unittest.TestCase):
             lang=cls.DEFAULT_LANG,
             default_pipeline=[cls.PIPELINE_ID],
             max_wait=cls.STARTUP_MAX_WAIT,
+            modernize=cls.MODERNIZE,
+            emit_legacy=cls.EMIT_LEGACY,
         )
         cls.pipeline = cls.mc.intents.pipeline_plugins[cls.PIPELINE_ID]
 

--- a/ovoscope/listener.py
+++ b/ovoscope/listener.py
@@ -283,6 +283,13 @@ class MiniListener:
         ww_instances: Optional mapping of hotword name →
             :class:`HotWordEngine` (or mock) instance.  Multiple wake-word
             engines can be registered simultaneously.
+        modernize: FakeBus also emits the ovos.* spec topic when a legacy
+            topic is emitted (legacy producer -> spec listener). The listener
+            pipeline emits legacy ``recognizer_loop:*`` topics; this bridge is
+            what lets a spec-topic subscriber observe them.
+        emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec
+            topic is emitted (spec producer -> legacy listener). Set both False
+            to exercise a single namespace with no bridging.
 
     Example::
 
@@ -308,8 +315,11 @@ class MiniListener:
         stt_instance: Optional[Any] = None,
         vad_instance: Optional[Any] = None,
         ww_instances: Optional[Dict[str, Any]] = None,
+        modernize: bool = True,
+        emit_legacy: bool = True,
     ) -> None:
-        self.bus: FakeBus = FakeBus()
+        self.bus: FakeBus = FakeBus(modernize=modernize,
+                                    emit_legacy=emit_legacy)
         self._messages: List[Message] = []
         self._stt_instance: Optional[Any] = stt_instance
         self._vad: Optional[Any] = vad_instance
@@ -688,6 +698,8 @@ def get_mini_listener(
     vad_instance: Optional[Any] = None,
     ww_plugin: Optional[str] = None,
     ww_instances: Optional[Dict[str, Any]] = None,
+    modernize: bool = True,
+    emit_legacy: bool = True,
 ) -> MiniListener:
     """Factory: create a ready-to-use :class:`MiniListener`.
 
@@ -717,6 +729,11 @@ def get_mini_listener(
         ww_instances: Mapping of hotword name → engine instance.  Supports
             multiple simultaneous wake-word engines.  Takes precedence over
             *ww_plugin*.
+        modernize: FakeBus also emits the ovos.* spec topic when a legacy topic
+            is emitted (legacy producer -> spec listener).
+        emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec
+            topic is emitted (spec producer -> legacy listener). Set both False
+            to exercise a single namespace with no bridging.
 
     Returns:
         A fully initialised :class:`MiniListener` ready to receive audio.
@@ -770,6 +787,8 @@ def get_mini_listener(
         stt_instance=stt_instance,
         vad_instance=resolved_vad,
         ww_instances=resolved_ww,
+        modernize=modernize,
+        emit_legacy=emit_legacy,
     )
 
 

--- a/ovoscope/media.py
+++ b/ovoscope/media.py
@@ -269,7 +269,9 @@ class OCPPlayerHarness:
     """
 
     def __init__(self, backend_namespace: str = "audio",
-                 backend_factory: Optional[Callable[[FakeBus], AudioBackend]] = None) -> None:
+                 backend_factory: Optional[Callable[[FakeBus], AudioBackend]] = None,
+                 modernize: bool = True,
+                 emit_legacy: bool = True) -> None:
         """Initialise harness parameters.
 
         Args:
@@ -284,9 +286,22 @@ class OCPPlayerHarness:
                 backend would otherwise reach. Note the mock-only assertion helpers
                 (:meth:`assert_backend_paused`, ``backend.played_uris``) assume a
                 :class:`MockOCPBackend` and may not apply to a real backend.
+            modernize: FakeBus also emits the ovos.* spec topic when a legacy
+                topic is emitted (legacy producer -> spec listener). OCPMediaPlayer
+                subscribes to the LEGACY duck/cork topics
+                (recognizer_loop:audio_output_start/end, record_begin/end); this
+                bridge lets a spec-namespace producer's ovos.audio.output.* /
+                ovos.listener.record.* reach those legacy handlers.
+            emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec
+                topic is emitted (spec producer -> legacy listener). Because the
+                player subscribes on the legacy topics, this is the bridge that
+                connects a spec producer to the player. Set both False to exercise
+                a single namespace with no bridging.
         """
         self.backend_namespace: str = backend_namespace
         self.backend_factory = backend_factory
+        self.modernize: bool = modernize
+        self.emit_legacy: bool = emit_legacy
         self.bus: Optional[FakeBus] = None
         self.player = None  # OCPMediaPlayer instance
         self.backend: Optional[AudioBackend] = None
@@ -301,7 +316,8 @@ class OCPPlayerHarness:
         """
         from ovos_media.player import OCPMediaPlayer
 
-        self.bus = FakeBus()
+        self.bus = FakeBus(modernize=self.modernize,
+                           emit_legacy=self.emit_legacy)
         if self.backend_factory is not None:
             self.backend = self.backend_factory(self.bus)
             # A config-loaded backend gets name/namespace from
@@ -624,9 +640,18 @@ class OCPCaptureSession:
     """
 
     bus: FakeBus
+    # capture BOTH the legacy and the ovos.* spec topics of the duck/cork
+    # messages the player consumes. The session observes the raw "message" wire
+    # stream, which carries the producer's ORIGINAL topic only (FakeBus' namespace
+    # bridging re-dispatches the counterpart as a typed event, not a second
+    # "message" event). Listing both namespaces lets the session record the
+    # sequence whether the producer emits legacy or spec.
     track_prefixes: List[str] = dataclasses.field(default_factory=lambda: [
         "ovos.common_play.",
         "ovos.audio.",
+        "recognizer_loop:audio_output",
+        "ovos.listener.record",
+        "recognizer_loop:record",
     ])
     messages: List[Message] = dataclasses.field(default_factory=list)
 

--- a/ovoscope/ocp.py
+++ b/ovoscope/ocp.py
@@ -67,6 +67,15 @@ class OCPTest:
         patch_targets: Additional ``requests``-like module paths to patch
             (e.g. ``["my_skill.http_client.requests"]``).  The default
             target is ``"requests.Session.get"``.
+        modernize: Forwarded to the harness ``MiniCroft`` / ``FakeBus``. When
+            on (default), emitting a LEGACY topic also dispatches its ovos.*
+            spec counterpart (legacy producer -> spec listener). The OCP flow
+            is driven by ``recognizer_loop:utterance``; bridging lets it be
+            observed on / driven from ``ovos.utterance.handle`` too.
+        emit_legacy: Forwarded to the harness. When on (default), emitting an
+            ovos.* spec topic also dispatches the legacy one (spec producer ->
+            legacy listener). Set BOTH False to exercise a single namespace
+            with no cross-namespace bridging.
 
     Example::
 
@@ -86,6 +95,8 @@ class OCPTest:
     lang: str = "en-US"
     timeout: float = 20.0
     patch_targets: List[str] = field(default_factory=list)
+    modernize: bool = True
+    emit_legacy: bool = True
 
     def execute(self) -> List[Message]:
         """Run the OCP test with optional HTTP mocking.
@@ -100,7 +111,9 @@ class OCPTest:
 
         captured: List[Message] = []
 
-        mc = get_minicroft(self.skill_ids, lang=self.lang, max_wait=60)
+        mc = get_minicroft(self.skill_ids, lang=self.lang, max_wait=60,
+                           modernize=self.modernize,
+                           emit_legacy=self.emit_legacy)
         mc.bus.on("message", lambda m: captured.append(
             Message.deserialize(m) if isinstance(m, str) else m
         ))

--- a/ovoscope/phal.py
+++ b/ovoscope/phal.py
@@ -58,6 +58,14 @@ class MiniPHAL:
             is always wired to the harness ``FakeBus``.  Takes precedence over
             *plugin_instances* for the same plugin_id.
         config: Per-plugin configuration overrides keyed by plugin_id.
+        modernize: FakeBus also emits the ovos.* spec topic when a legacy topic
+            is emitted (legacy producer -> spec listener). PHAL plugins do not use
+            any of the migrated audio/listener topics, so this only matters for a
+            plugin that happens to consume/produce a migrated topic; it is threaded
+            for consistency with the audio/media harnesses.
+        emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec topic
+            is emitted (spec producer -> legacy listener). Set both False to
+            exercise a single namespace with no bridging.
 
     Example::
 
@@ -86,12 +94,16 @@ class MiniPHAL:
         plugin_instances: Optional[Dict[str, Any]] = None,
         plugin_factories: Optional[Dict[str, Callable[[FakeBus], Any]]] = None,
         config: Optional[Dict[str, Dict[str, Any]]] = None,
+        modernize: bool = True,
+        emit_legacy: bool = True,
     ) -> None:
         self.plugin_ids: List[str] = plugin_ids or []
         self.plugin_instances: Dict[str, Any] = plugin_instances or {}
         self.plugin_factories: Dict[str, Callable[[FakeBus], Any]] = plugin_factories or {}
         self.config: Dict[str, Dict[str, Any]] = config or {}
-        self._bus: FakeBus = FakeBus()
+        self.modernize: bool = modernize
+        self.emit_legacy: bool = emit_legacy
+        self._bus: FakeBus = FakeBus(modernize=modernize, emit_legacy=emit_legacy)
         self._captured: List[Message] = []
         self._loaded: Dict[str, Any] = {}
 
@@ -249,6 +261,9 @@ class PHALTest:
             Use this when the plugin must be constructed with the harness bus.
         config: Per-plugin config overrides.
         timeout: Maximum seconds to wait for expected messages (default 5.0).
+        modernize: Forwarded to :class:`MiniPHAL` — FakeBus bridges legacy->spec.
+        emit_legacy: Forwarded to :class:`MiniPHAL` — FakeBus bridges spec->legacy.
+            Set both False to exercise a single namespace with no bridging.
 
     Example::
 
@@ -271,6 +286,8 @@ class PHALTest:
     plugin_factories: Dict[str, Callable[[FakeBus], Any]] = field(default_factory=dict)
     config: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     timeout: float = 5.0
+    modernize: bool = True
+    emit_legacy: bool = True
 
     def execute(self) -> List[Message]:
         """Run the test: load plugins, emit trigger, assert expectations.
@@ -286,6 +303,8 @@ class PHALTest:
             plugin_instances=self.plugin_instances,
             plugin_factories=self.plugin_factories,
             config=self.config,
+            modernize=self.modernize,
+            emit_legacy=self.emit_legacy,
         ) as phal:
             phal.emit(self.trigger_message, wait=0.1)
 

--- a/ovoscope/pipeline.py
+++ b/ovoscope/pipeline.py
@@ -95,6 +95,15 @@ class PipelineHarness:
         pipeline: List of OPM pipeline stage IDs to load.
         pipeline_config: Per-stage config overrides keyed by stage ID.
         lang: Language tag (default ``"en-US"``).
+        modernize: Forwarded to the harness ``MiniCroft`` / ``FakeBus``. When
+            on (default), emitting a LEGACY topic also dispatches its ovos.*
+            spec counterpart (legacy producer -> spec listener). Utterances are
+            injected via ``recognizer_loop:utterance``; bridging lets them also
+            drive / be observed on ``ovos.utterance.handle``.
+        emit_legacy: Forwarded to the harness. When on (default), emitting an
+            ovos.* spec topic also dispatches the legacy one (spec producer ->
+            legacy listener). Set BOTH False to exercise a single namespace
+            with no cross-namespace bridging.
 
     Example::
 
@@ -111,10 +120,14 @@ class PipelineHarness:
         pipeline: Optional[List[str]] = None,
         pipeline_config: Optional[Dict[str, Dict[str, Any]]] = None,
         lang: str = "en-US",
+        modernize: bool = True,
+        emit_legacy: bool = True,
     ) -> None:
         self.pipeline: List[str] = pipeline or []
         self.pipeline_config: Dict[str, Dict[str, Any]] = pipeline_config or {}
         self.lang: str = lang
+        self.modernize: bool = modernize
+        self.emit_legacy: bool = emit_legacy
         self._mc: Any = None
 
     # ------------------------------------------------------------------
@@ -135,6 +148,8 @@ class PipelineHarness:
             default_pipeline=self.pipeline or None,
             extra_skills={"__ovoscope_sink__": sink_skill},
             max_wait=60,
+            modernize=self.modernize,
+            emit_legacy=self.emit_legacy,
         )
 
         # Update sink skill's bus reference now that MiniCroft is created

--- a/ovoscope/simple_listener.py
+++ b/ovoscope/simple_listener.py
@@ -100,6 +100,14 @@ class MiniSimpleListener(ListenerHarness):
         max_silence_seconds: Trailing silence that ends a command.
         max_speech_seconds: Hard cap on command length.
         bus: Optional :class:`FakeBus` to capture on.
+        modernize: When a fresh bus is created, also emit the ovos.* spec topic
+            whenever a legacy topic is emitted (legacy producer -> spec
+            listener). The ``_SimpleBusCallbacks`` emit legacy
+            ``recognizer_loop:*`` topics; this bridge lets a spec-topic
+            subscriber observe them. Ignored when *bus* is supplied.
+        emit_legacy: When a fresh bus is created, also emit the legacy topic
+            whenever an ovos.* spec topic is emitted. Set both False to exercise
+            a single namespace with no bridging. Ignored when *bus* is supplied.
 
     Raises:
         RuntimeError: If ovos-simple-listener is not installed.
@@ -119,8 +127,10 @@ class MiniSimpleListener(ListenerHarness):
         max_silence_seconds: float = 0.1,
         max_speech_seconds: float = 8.0,
         bus: Optional[FakeBus] = None,
+        modernize: bool = True,
+        emit_legacy: bool = True,
     ) -> None:
-        super().__init__(bus)
+        super().__init__(bus, modernize=modernize, emit_legacy=emit_legacy)
 
         try:
             from ovos_simple_listener import SimpleListener
@@ -202,6 +212,8 @@ def get_mini_simple_listener(
     vad_instance: Optional[Any] = None,
     stt_instance: Optional[Any] = None,
     bus: Optional[FakeBus] = None,
+    modernize: bool = True,
+    emit_legacy: bool = True,
 ) -> MiniSimpleListener:
     """Factory: create a ready-to-feed :class:`MiniSimpleListener`.
 
@@ -211,6 +223,12 @@ def get_mini_simple_listener(
         stt_instance: Streaming STT engine (defaults to
             :class:`MockStreamingSTT`).
         bus: Optional :class:`FakeBus` to capture on.
+        modernize: When a fresh bus is created, also emit the ovos.* spec topic
+            whenever a legacy topic is emitted (legacy producer -> spec
+            listener). Ignored when *bus* is supplied.
+        emit_legacy: When a fresh bus is created, also emit the legacy topic
+            whenever an ovos.* spec topic is emitted. Set both False to exercise
+            a single namespace with no bridging. Ignored when *bus* is supplied.
 
     Returns:
         A fully initialised :class:`MiniSimpleListener`.
@@ -220,4 +238,6 @@ def get_mini_simple_listener(
         vad_instance=vad_instance,
         stt_instance=stt_instance,
         bus=bus,
+        modernize=modernize,
+        emit_legacy=emit_legacy,
     )

--- a/ovoscope/voice_loop.py
+++ b/ovoscope/voice_loop.py
@@ -501,10 +501,21 @@ class ListenerHarness:
 
     Args:
         bus: Optional :class:`FakeBus` to capture on.  Defaults to a fresh bus.
+        modernize: When a fresh bus is created, also emit the ovos.* spec topic
+            whenever a legacy topic is emitted (legacy producer -> spec
+            listener). The listener callbacks emit legacy ``recognizer_loop:*``
+            topics; this bridge is what lets a spec-topic subscriber observe
+            them. Ignored when *bus* is supplied.
+        emit_legacy: When a fresh bus is created, also emit the legacy topic
+            whenever an ovos.* spec topic is emitted (spec producer -> legacy
+            listener). Set both False to exercise a single namespace with no
+            bridging. Ignored when *bus* is supplied.
     """
 
-    def __init__(self, bus: Optional[FakeBus] = None) -> None:
-        self.bus: FakeBus = bus if bus is not None else FakeBus()
+    def __init__(self, bus: Optional[FakeBus] = None,
+                 modernize: bool = True, emit_legacy: bool = True) -> None:
+        self.bus: FakeBus = bus if bus is not None else FakeBus(
+            modernize=modernize, emit_legacy=emit_legacy)
         self._messages: List[Message] = []
         self._last_messages: List[Message] = []
         self.bus.on("message", self._capture)
@@ -696,6 +707,12 @@ class MiniVoiceLoop(ListenerHarness):
             :class:`MockStreamingSTT` returning no transcript).  Used by
             :meth:`feed_file`.
         bus: Optional :class:`FakeBus` to capture on.  Defaults to a fresh bus.
+        modernize: When a fresh bus is created, also emit the ovos.* spec topic
+            whenever a legacy topic is emitted (legacy producer -> spec
+            listener). Ignored when *bus* is supplied.
+        emit_legacy: When a fresh bus is created, also emit the legacy topic
+            whenever an ovos.* spec topic is emitted. Set both False to exercise
+            a single namespace with no bridging. Ignored when *bus* is supplied.
 
     Raises:
         RuntimeError: If *voice_loop* is ``None`` and ovos-dinkum-listener is not
@@ -720,8 +737,10 @@ class MiniVoiceLoop(ListenerHarness):
         vad_instance: Optional[Any] = None,
         stt_instance: Optional[Any] = None,
         bus: Optional[FakeBus] = None,
+        modernize: bool = True,
+        emit_legacy: bool = True,
     ) -> None:
-        super().__init__(bus)
+        super().__init__(bus, modernize=modernize, emit_legacy=emit_legacy)
 
         self.hotwords: Optional[MiniHotwordContainer] = None
         if voice_loop is not None:
@@ -924,6 +943,8 @@ def get_mini_voice_loop(
     vad_instance: Optional[Any] = None,
     stt_instance: Optional[Any] = None,
     bus: Optional[FakeBus] = None,
+    modernize: bool = True,
+    emit_legacy: bool = True,
 ) -> MiniVoiceLoop:
     """Factory: create a ready-to-feed :class:`MiniVoiceLoop`.
 
@@ -935,6 +956,12 @@ def get_mini_voice_loop(
         stt_instance: Optional streaming STT engine (defaults to
             :class:`MockStreamingSTT`).
         bus: Optional :class:`FakeBus` to capture on.
+        modernize: When a fresh bus is created, also emit the ovos.* spec topic
+            whenever a legacy topic is emitted (legacy producer -> spec
+            listener). Ignored when *bus* is supplied.
+        emit_legacy: When a fresh bus is created, also emit the legacy topic
+            whenever an ovos.* spec topic is emitted. Set both False to exercise
+            a single namespace with no bridging. Ignored when *bus* is supplied.
 
     Returns:
         A fully initialised :class:`MiniVoiceLoop`.
@@ -957,6 +984,8 @@ def get_mini_voice_loop(
         vad_instance=vad_instance,
         stt_instance=stt_instance,
         bus=bus,
+        modernize=modernize,
+        emit_legacy=emit_legacy,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
     # Alpha pin: 2.0.4 stable not yet released; 2.0.4a2 is the minimum that
     # includes the FakeBus-compatible SkillManager changes ovoscope depends on.
     "ovos-core>=2.0.4a2",
+    # The audio harness emits/observes the ovos.* spec topics while ovos-audio
+    # still produces the legacy topics. >=0.12.0a1 is the first FakeBus that
+    # mirrors MessageBusClient's legacy<->ovos.* namespace migration (ovos-utils
+    # #381), so a legacy producer reaches a spec listener (and vice-versa) on the
+    # test double. Prerelease floor pin: resolves without --pre.
+    "ovos-utils>=0.12.0a1",
     # ovoscope ships a pytest plugin (pytest11 entry point) -> pytest is a runtime
     # dependency. >=8 is required: the pytest_pycollect_makemodule hook dropped the
     # 'path' argument in pytest 8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ classifiers = [
 
 [project.optional-dependencies]
 pydantic = ["ovos-pydantic-models>=0.1.0"]
-audio = ["ovos-audio>=1.2.0"]
+# The audio harness emits/asserts on the OVOS spec bus namespace via SpecMessage.
+audio = ["ovos-audio>=1.4.0a1", "ovos-spec-tools>=0.9.0a1"]
 # OCP / ovos-media player harnesses (ovoscope.media: OCPPlayerHarness, ...).
 media = ["ovos-media>=0.0.2a3"]
 # MiniListener plugin_instances path (feed_audio_stream) needs the dinkum
@@ -42,7 +43,7 @@ listener = ["ovos-dinkum-listener>=0.7.2a1"]
 # faster-whisper itself is pulled by the plugin — don't list it here to avoid
 # version skew.
 tts = [
-    "ovos-audio>=1.2.0",
+    "ovos-audio>=1.4.0a1",
     "jiwer",
     "ovos-utterance-normalizer",
     "ovos-stt-plugin-fasterwhisper",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,10 @@ classifiers = [
 
 [project.optional-dependencies]
 pydantic = ["ovos-pydantic-models>=0.1.0"]
-# The audio harness emits/asserts on the OVOS spec bus namespace via SpecMessage.
-audio = ["ovos-audio>=1.3.0a1", "ovos-spec-tools>=0.9.0a1"]
+# The audio harness emits/asserts on the OVOS spec bus namespace via SpecMessage,
+# and the FakeBus bridging (ovos-utils) imports NamespaceTranslator — new in
+# ovos-spec-tools 0.10.0a1, so that is the real floor.
+audio = ["ovos-audio>=1.3.0a1", "ovos-spec-tools>=0.10.0a1"]
 # OCP / ovos-media player harnesses (ovoscope.media: OCPPlayerHarness, ...).
 media = ["ovos-media>=0.0.2a3"]
 # MiniListener plugin_instances path (feed_audio_stream) needs the dinkum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ tts = [
     "ovos-stt-plugin-fasterwhisper",
 ]
 dev = [
-    "ovos-audio>=1.2.0",
+    "ovos-audio>=1.3.0a1",
     "ovos-media>=0.0.2a3",
     "ovos-dinkum-listener>=0.7.2a1",
     "ovos-pydantic-models>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 [project.optional-dependencies]
 pydantic = ["ovos-pydantic-models>=0.1.0"]
 # The audio harness emits/asserts on the OVOS spec bus namespace via SpecMessage.
-audio = ["ovos-audio>=1.4.0a1", "ovos-spec-tools>=0.9.0a1"]
+audio = ["ovos-audio>=1.3.0a1", "ovos-spec-tools>=0.9.0a1"]
 # OCP / ovos-media player harnesses (ovoscope.media: OCPPlayerHarness, ...).
 media = ["ovos-media>=0.0.2a3"]
 # MiniListener plugin_instances path (feed_audio_stream) needs the dinkum
@@ -43,7 +43,7 @@ listener = ["ovos-dinkum-listener>=0.7.2a1"]
 # faster-whisper itself is pulled by the plugin — don't list it here to avoid
 # version skew.
 tts = [
-    "ovos-audio>=1.4.0a1",
+    "ovos-audio>=1.3.0a1",
     "jiwer",
     "ovos-utterance-normalizer",
     "ovos-stt-plugin-fasterwhisper",

--- a/test/unittests/test_audio_harness.py
+++ b/test/unittests/test_audio_harness.py
@@ -439,5 +439,59 @@ class TestAudioCaptureSession(unittest.TestCase):
             cap.assert_sequence("recognizer_loop:audio_output_end")
 
 
+# ---------------------------------------------------------------------------
+# TestAudioHarnessNamespaceBridging
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(AUDIO_AVAILABLE, "ovos-audio (audio extra) not installed")
+class TestAudioHarnessNamespaceBridging(unittest.TestCase):
+    """The audio harness subscribes on the ovos.* SPEC topics while ovos-audio
+    emits the LEGACY topics. These tests pin that the FakeBus namespace bridging
+    is what connects them, and that turning it off isolates a single namespace.
+    """
+
+    def test_ducking_works_via_bridging_default(self) -> None:
+        """Default harness (bridging on): ovos-audio's legacy
+        recognizer_loop:audio_output_start reaches the spec-subscribed
+        _lower_volume_on_speak via modernize bridging."""
+        with AudioServiceHarness() as h:  # modernize/emit_legacy default on
+            h.play(["http://example.com/song.mp3"])
+            h.bus.emit(Message("recognizer_loop:audio_output_start"))
+            start = time.monotonic()
+            while h.backend.lower_volume_calls == 0 and time.monotonic() - start < 2.0:
+                time.sleep(0.01)
+            h.assert_volume_lowered()
+
+    def test_ducking_via_spec_topic_directly(self) -> None:
+        """A SPEC producer (ovos.audio.output.started) also reaches the
+        spec-subscribed ducking handler — the harness exercises the new namespace
+        natively too."""
+        from ovos_spec_tools import SpecMessage
+        with AudioServiceHarness() as h:
+            h.play(["http://example.com/song.mp3"])
+            h.bus.emit(Message(str(SpecMessage.AUDIO_OUTPUT_STARTED)))
+            start = time.monotonic()
+            while h.backend.lower_volume_calls == 0 and time.monotonic() - start < 2.0:
+                time.sleep(0.01)
+            h.assert_volume_lowered()
+
+    def test_no_bridging_isolates_legacy_from_spec(self) -> None:
+        """With bridging OFF, a legacy emit does NOT reach the spec-subscribed
+        ducking handler — proving the harness can exercise a single namespace."""
+        with AudioServiceHarness(modernize=False, emit_legacy=False) as h:
+            h.play(["http://example.com/song.mp3"])
+            h.bus.emit(Message("recognizer_loop:audio_output_start"))
+            time.sleep(0.3)  # give any (incorrect) bridge a chance to fire
+            self.assertEqual(h.backend.lower_volume_calls, 0)
+
+    def test_speak_lifecycle_via_bridging(self) -> None:
+        """PlaybackService emits legacy audio_output_start/end; the harness
+        observes them on the spec topics via bridging (default on)."""
+        with PlaybackServiceHarness() as h:
+            h.speak("namespace test")
+            h.assert_audio_output_started()
+            h.assert_audio_output_ended()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_classic_listener.py
+++ b/test/unittests/test_classic_listener.py
@@ -21,6 +21,7 @@ import io
 import unittest
 import wave
 
+from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 
 from ovoscope.classic_listener import (
@@ -35,6 +36,12 @@ try:
     HAS_PYEE = True
 except ImportError:
     HAS_PYEE = False
+
+try:
+    from ovos_spec_tools import SpecMessage
+    HAS_SPEC = True
+except ImportError:
+    HAS_SPEC = False
 
 HAS_CLASSIC = classic_listener_available()
 
@@ -104,6 +111,102 @@ class TestMiniClassicListenerFileDrive(unittest.TestCase):
             self.assertIn("recognizer_loop:record_begin", types)
             self.assertIn("recognizer_loop:record_end", types)
             cl.assert_utterance_emitted("hello world", msgs)
+
+
+@unittest.skipUnless(HAS_PYEE, "pyee not installed")
+@unittest.skipUnless(HAS_SPEC, "ovos-spec-tools not installed")
+class TestClassicListenerNamespaceBridging(unittest.TestCase):
+    """The classic listener bridge emits the LEGACY recognizer_loop:* /
+    mycroft.awoken topics, while OVOS migrates them to the ovos.* SPEC namespace.
+    These tests pin that the harness FakeBus namespace bridging connects the two,
+    and that turning it off isolates a single namespace.
+
+    Migrated pairs exercised here (legacy -> spec):
+        recognizer_loop:utterance     -> ovos.utterance.handle
+        recognizer_loop:record_begin  -> ovos.listener.record.started
+        recognizer_loop:record_end    -> ovos.listener.record.ended
+        mycroft.awoken                -> ovos.listener.awoken
+    """
+
+    def _harness(self, **kwargs):
+        """Build a MiniClassicListener around a plain EventEmitter loop.
+
+        No classic listener install is needed — the bridge drives any
+        EventEmitter and re-emits its events onto the harness FakeBus.
+        """
+        return MiniClassicListener(recognizer_loop=EventEmitter(), **kwargs)
+
+    def test_utterance_legacy_reaches_spec_default(self):
+        """Default harness (bridging on): the bridge's legacy
+        recognizer_loop:utterance reaches an ovos.utterance.handle subscriber."""
+        h = self._harness()  # modernize/emit_legacy default on
+        seen = []
+        h.bus.on(str(SpecMessage.UTTERANCE), lambda m: seen.append(m.msg_type))
+        h.loop.emit("recognizer_loop:utterance",
+                    {"utterances": ["hello world"], "lang": "en-us"})
+        self.assertIn(str(SpecMessage.UTTERANCE), seen)
+
+    def test_utterance_spec_reaches_legacy_default(self):
+        """Default harness (bridging on): a SPEC producer of
+        ovos.utterance.handle reaches a legacy recognizer_loop:utterance
+        subscriber — the new namespace is exercised natively too."""
+        h = self._harness()
+        seen = []
+        h.bus.on("recognizer_loop:utterance", lambda m: seen.append(m.msg_type))
+        h.bus.emit(Message(str(SpecMessage.UTTERANCE),
+                           {"utterances": ["hello world"]}))
+        self.assertIn("recognizer_loop:utterance", seen)
+
+    def test_record_begin_end_bridge_to_spec(self):
+        """The bridge's record_begin/record_end reach their spec counterparts."""
+        h = self._harness()
+        started, ended = [], []
+        h.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED),
+                 lambda m: started.append(m.msg_type))
+        h.bus.on(str(SpecMessage.LISTENER_RECORD_ENDED),
+                 lambda m: ended.append(m.msg_type))
+        h.loop.emit("recognizer_loop:record_begin")
+        h.loop.emit("recognizer_loop:record_end")
+        self.assertIn(str(SpecMessage.LISTENER_RECORD_STARTED), started)
+        self.assertIn(str(SpecMessage.LISTENER_RECORD_ENDED), ended)
+
+    def test_awoken_bridges_to_spec(self):
+        """The bridge maps recognizer_loop:awoken -> mycroft.awoken, which
+        migrates to ovos.listener.awoken via modernize bridging."""
+        h = self._harness()
+        seen = []
+        h.bus.on(str(SpecMessage.LISTENER_AWOKEN), lambda m: seen.append(m.msg_type))
+        h.loop.emit("recognizer_loop:awoken")
+        self.assertIn(str(SpecMessage.LISTENER_AWOKEN), seen)
+
+    def test_awoken_spec_reaches_legacy_default(self):
+        """A SPEC producer of ovos.listener.awoken reaches a legacy
+        mycroft.awoken subscriber via emit_legacy bridging."""
+        h = self._harness()
+        seen = []
+        h.bus.on("mycroft.awoken", lambda m: seen.append(m.msg_type))
+        h.bus.emit(Message(str(SpecMessage.LISTENER_AWOKEN)))
+        self.assertIn("mycroft.awoken", seen)
+
+    def test_no_bridging_isolates_legacy_from_spec(self):
+        """With bridging OFF, the bridge's legacy emits do NOT reach the
+        spec-only subscribers — proving a single namespace can be exercised."""
+        h = self._harness(modernize=False, emit_legacy=False)
+        utt, started, ended, awoken = [], [], [], []
+        h.bus.on(str(SpecMessage.UTTERANCE), lambda m: utt.append(m))
+        h.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED), lambda m: started.append(m))
+        h.bus.on(str(SpecMessage.LISTENER_RECORD_ENDED), lambda m: ended.append(m))
+        h.bus.on(str(SpecMessage.LISTENER_AWOKEN), lambda m: awoken.append(m))
+
+        h.loop.emit("recognizer_loop:utterance", {"utterances": ["hi"]})
+        h.loop.emit("recognizer_loop:record_begin")
+        h.loop.emit("recognizer_loop:record_end")
+        h.loop.emit("recognizer_loop:awoken")
+
+        self.assertEqual(utt, [])
+        self.assertEqual(started, [])
+        self.assertEqual(ended, [])
+        self.assertEqual(awoken, [])
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_listener_vad_ww.py
+++ b/test/unittests/test_listener_vad_ww.py
@@ -20,7 +20,13 @@ TestMiniListenerWakeWord (9 tests) — MiniListener WakeWord integration
 TestVADTest              (5 tests) — VADTest declarative helper
 TestWakeWordTest         (5 tests) — WakeWordTest declarative helper
 """
+import importlib.util
+import time
 import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 
 from ovoscope.listener import (
     MockHotWordEngine,
@@ -30,6 +36,10 @@ from ovoscope.listener import (
     WakeWordTest,
     get_mini_listener,
 )
+
+# MiniListener.listen() routes audio through AudioTransformersService before
+# emitting recognizer_loop:utterance, which requires ovos-dinkum-listener.
+DINKUM_AVAILABLE = importlib.util.find_spec("ovos_dinkum_listener") is not None
 
 
 _BASE_CONFIG = {"listener": {"audio_transformers": {}}}
@@ -439,6 +449,74 @@ class TestWakeWordTest(unittest.TestCase):
         """WakeWordTest without ww_instances or ww_plugin raises RuntimeError."""
         with self.assertRaises(RuntimeError):
             WakeWordTest(audio_chunks=[b"\x00" * 512] * 3).execute()
+
+
+# ---------------------------------------------------------------------------
+# TestMiniListenerNamespaceBridging
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(
+    DINKUM_AVAILABLE, "ovos-dinkum-listener not installed"
+)
+class TestMiniListenerNamespaceBridging(unittest.TestCase):
+    """MiniListener.listen() emits the LEGACY ``recognizer_loop:utterance``
+    (migrated to ``ovos.utterance.handle``).  These tests pin that the FakeBus
+    namespace bridging connects the two namespaces, and that turning it off
+    isolates a single namespace.
+    """
+
+    @staticmethod
+    def _stt(transcript):
+        stt = MagicMock()
+        stt.execute.return_value = transcript
+        return stt
+
+    def test_utterance_legacy_reaches_spec_via_bridging(self):
+        """Default harness (bridging on): the legacy utterance emitted by
+        listen() also reaches a subscriber on the spec topic."""
+        listener = get_mini_listener(stt_instance=self._stt("hello world"))
+        legacy_hits, spec_hits = [], []
+        listener.bus.on("recognizer_loop:utterance", lambda m: legacy_hits.append(m))
+        listener.bus.on(str(SpecMessage.UTTERANCE), lambda m: spec_hits.append(m))
+        try:
+            listener.listen(b"\x00" * 1024, language="en-us")
+            time.sleep(0.05)
+            self.assertTrue(legacy_hits, "legacy recognizer_loop:utterance not seen")
+            self.assertTrue(spec_hits, "spec ovos.utterance.handle not seen via bridge")
+        finally:
+            listener.shutdown()
+
+    def test_utterance_spec_native(self):
+        """A SPEC producer (ovos.utterance.handle) reaches a spec subscriber
+        natively — the harness bus exercises the new namespace too."""
+        listener = get_mini_listener()
+        spec_hits = []
+        listener.bus.on(str(SpecMessage.UTTERANCE), lambda m: spec_hits.append(m))
+        try:
+            listener.bus.emit(Message(str(SpecMessage.UTTERANCE),
+                                      {"utterances": ["hi"], "lang": "en-us"}))
+            time.sleep(0.05)
+            self.assertTrue(spec_hits, "spec ovos.utterance.handle not delivered")
+        finally:
+            listener.shutdown()
+
+    def test_no_bridging_isolates_legacy_from_spec(self):
+        """With bridging OFF, the legacy utterance emitted by listen() does NOT
+        reach a spec-only subscriber."""
+        listener = get_mini_listener(
+            stt_instance=self._stt("hello world"),
+            modernize=False, emit_legacy=False,
+        )
+        legacy_hits, spec_hits = [], []
+        listener.bus.on("recognizer_loop:utterance", lambda m: legacy_hits.append(m))
+        listener.bus.on(str(SpecMessage.UTTERANCE), lambda m: spec_hits.append(m))
+        try:
+            listener.listen(b"\x00" * 1024, language="en-us")
+            time.sleep(0.1)
+            self.assertTrue(legacy_hits, "legacy utterance should still fire")
+            self.assertEqual(spec_hits, [], "spec topic must not fire with bridging off")
+        finally:
+            listener.shutdown()
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_media.py
+++ b/test/unittests/test_media.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Unit tests for ovoscope.media (MockOCPBackend, OCPCaptureSession, OCPPlayerHarness)."""
 
+import time
+
 import pytest
 from unittest.mock import MagicMock
 
@@ -296,3 +298,65 @@ class TestOCPPlayerHarnessBackendInjection:
                               playback=PlaybackType.AUDIO))
             assert h.backend.is_playing is True
             assert h.backend.play_calls == ["library://track/42"]
+
+
+# ---------------------------------------------------------------------------
+# Namespace bridging
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _HAS_OVOS_MEDIA,
+                    reason="requires the [media] extra (ovos-media)")
+class TestOCPHarnessNamespaceBridging:
+    """OCPMediaPlayer subscribes to the LEGACY duck/cork topics
+    (``recognizer_loop:audio_output_start/end``, ``recognizer_loop:record_begin/end``)
+    which OVOS is migrating to the ``ovos.*`` spec namespace
+    (``ovos.audio.output.*`` / ``ovos.listener.record.*``). These tests pin that
+    the harness FakeBus namespace bridging connects a SPEC-namespace producer to
+    those legacy handlers, and that turning the bridge off isolates a single
+    namespace.
+
+    The observable behaviour is the *cork* path: while PLAYING, a record-start
+    event pauses the player (``handle_cork_request``).
+    """
+
+    @staticmethod
+    def _play_then(h):
+        """Drive the player into PLAYING with an AUDIO MediaEntry."""
+        from ovos_utils.ocp import MediaEntry, PlaybackType, PlayerState
+        h.play(MediaEntry(uri="http://example.com/song.mp3",
+                          playback=PlaybackType.AUDIO))
+        h.assert_player_state(PlayerState.PLAYING)
+
+    def test_cork_via_legacy_topic_natively(self) -> None:
+        """The legacy ``recognizer_loop:record_begin`` corks (pauses) the player —
+        the namespace the player subscribes on works natively."""
+        from ovos_utils.ocp import PlayerState
+        with OCPPlayerHarness() as h:  # bridging default on
+            self._play_then(h)
+            h.bus.emit(Message("recognizer_loop:record_begin"))
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PAUSED)
+
+    def test_cork_via_spec_topic_through_bridging(self) -> None:
+        """A SPEC producer emitting ``ovos.listener.record.started`` reaches the
+        legacy-subscribed ``handle_cork_request`` via emit_legacy bridging and
+        corks (pauses) the player."""
+        from ovos_spec_tools import SpecMessage
+        from ovos_utils.ocp import PlayerState
+        with OCPPlayerHarness() as h:  # bridging default on
+            self._play_then(h)
+            h.bus.emit(Message(str(SpecMessage.LISTENER_RECORD_STARTED)))
+            time.sleep(0.05)
+            h.assert_player_state(PlayerState.PAUSED)
+
+    def test_no_bridging_isolates_spec_from_legacy(self) -> None:
+        """With bridging OFF, a SPEC ``ovos.listener.record.started`` emit does
+        NOT reach the legacy-subscribed cork handler — the player stays PLAYING,
+        proving the harness can exercise a single namespace."""
+        from ovos_spec_tools import SpecMessage
+        from ovos_utils.ocp import PlayerState
+        with OCPPlayerHarness(modernize=False, emit_legacy=False) as h:
+            self._play_then(h)
+            h.bus.emit(Message(str(SpecMessage.LISTENER_RECORD_STARTED)))
+            time.sleep(0.2)  # give any (incorrect) bridge a chance to fire
+            h.assert_player_state(PlayerState.PLAYING)

--- a/test/unittests/test_minicroft.py
+++ b/test/unittests/test_minicroft.py
@@ -3,12 +3,16 @@ import threading
 import unittest
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_utils.log import LOG
 from ovos_workshop.skills.ovos import OVOSSkill
 
 from ovos_bus_client.session import SessionManager
 
 from ovoscope import MiniCroft, get_minicroft, DEFAULT_TEST_PIPELINE, LIGHT_TEST_PIPELINE, ADAPT_PIPELINE
+
+LEGACY_UTTERANCE = "recognizer_loop:utterance"
+SPEC_UTTERANCE = str(SpecMessage.UTTERANCE)  # ovos.utterance.handle
 
 
 # ---------------------------------------------------------------------------
@@ -322,6 +326,76 @@ class TestMiniCroftPipelineConfig(unittest.TestCase):
         cfg_after = Configuration().get("intents", {})
         self.assertIsNone(cfg_after.get("plugin_a"))
         self.assertIsNone(cfg_after.get("plugin_b"))
+
+
+class TestMiniCroftNamespaceBridging(unittest.TestCase):
+    """MiniCroft is the e2e harness bus. Utterances are injected on the LEGACY
+    topic (``recognizer_loop:utterance``); these tests pin that MiniCroft's
+    FakeBus bridges that to/from the ovos.* SPEC topic
+    (``ovos.utterance.handle``) so an e2e test can drive EITHER namespace, and
+    that disabling the bridge isolates a single namespace.
+    """
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def _emit_and_collect(self, mc, emit_topic, watch_topic, *, timeout=3.0):
+        seen = []
+        got = threading.Event()
+
+        def _on(msg):
+            if isinstance(msg, str):
+                msg = Message.deserialize(msg)
+            seen.append(msg)
+            got.set()
+
+        mc.bus.on(watch_topic, _on)
+        try:
+            mc.bus.emit(Message(
+                emit_topic,
+                data={"utterances": ["hello world"], "lang": "en-US"},
+            ))
+            got.wait(timeout)
+        finally:
+            mc.bus.remove(watch_topic, _on)
+        return seen
+
+    def test_legacy_utterance_observed_on_spec_topic(self):
+        """Default (bridging on): a legacy recognizer_loop:utterance injected
+        into the e2e harness is observed on ovos.utterance.handle (modernize)."""
+        mc = get_minicroft([])  # modernize/emit_legacy default on
+        try:
+            seen = self._emit_and_collect(mc, LEGACY_UTTERANCE, SPEC_UTTERANCE)
+            self.assertTrue(seen, "legacy utterance was not bridged to the spec topic")
+            self.assertEqual(seen[0].data["utterances"], ["hello world"])
+        finally:
+            mc.stop()
+
+    def test_spec_utterance_reaches_legacy_listener(self):
+        """An utterance injected on the SPEC topic reaches a LEGACY listener
+        (emit_legacy) — the intent pipeline keys off the legacy topic."""
+        mc = get_minicroft([])
+        try:
+            seen = self._emit_and_collect(mc, SPEC_UTTERANCE, LEGACY_UTTERANCE)
+            self.assertTrue(seen, "spec utterance was not bridged to the legacy topic")
+            self.assertEqual(seen[0].data["utterances"], ["hello world"])
+        finally:
+            mc.stop()
+
+    def test_no_bridging_isolates_legacy_from_spec(self):
+        """With bridging OFF, a legacy emit does NOT reach a spec-only
+        subscriber — the e2e harness exercises a single isolated namespace."""
+        mc = get_minicroft([], modernize=False, emit_legacy=False)
+        try:
+            seen = self._emit_and_collect(mc, LEGACY_UTTERANCE, SPEC_UTTERANCE,
+                                          timeout=0.5)
+            self.assertEqual(seen, [],
+                             "legacy emit must not reach the spec topic when bridging is off")
+        finally:
+            mc.stop()
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_namespace_bridging.py
+++ b/test/unittests/test_namespace_bridging.py
@@ -1,0 +1,166 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end tests for the FakeBus legacy<->ovos.* namespace migration.
+
+The ovoscope harness runs components on a :class:`ovos_utils.fakebus.FakeBus`
+that mirrors ``MessageBusClient``'s namespace migration (ovos-utils #381): with
+``modernize``/``emit_legacy`` on (the defaults), emitting a topic on one
+namespace ALSO dispatches its counterpart on the other, and a handler subscribed
+to both topics fires once. These tests pin that behaviour through the harness bus
+so an ovoscope test can deliberately exercise EITHER namespace, BOTH, or a single
+isolated namespace.
+
+The pairs come from ``ovos_spec_tools.MIGRATION_MAP`` (legacy -> SpecMessage),
+e.g. ``speak`` <-> ``ovos.utterance.speak`` and
+``recognizer_loop:utterance`` <-> ``ovos.utterance.handle``.
+"""
+
+import threading
+import time
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+from ovos_spec_tools import SpecMessage
+from ovos_spec_tools.messages import MIGRATION_MAP
+
+
+# Representative migrating pairs (legacy topic, spec topic).
+LEGACY_SPEAK = "speak"
+SPEC_SPEAK = str(SpecMessage.SPEAK)               # ovos.utterance.speak
+LEGACY_UTTERANCE = "recognizer_loop:utterance"
+SPEC_UTTERANCE = str(SpecMessage.UTTERANCE)       # ovos.utterance.handle
+
+
+def _collect(bus, topic):
+    """Subscribe a counting handler on ``topic``; return its list of payloads."""
+    received = []
+    bus.on(topic, lambda m: received.append(m))
+    return received
+
+
+class TestFakeBusNamespaceBridging(unittest.TestCase):
+    """Both-namespace e2e coverage through the ovoscope harness FakeBus."""
+
+    def test_migration_map_is_populated(self) -> None:
+        """Sanity: the spec pairs this suite asserts on are actually migrated."""
+        self.assertEqual(MIGRATION_MAP[LEGACY_SPEAK], SpecMessage.SPEAK)
+        self.assertEqual(MIGRATION_MAP[LEGACY_UTTERANCE], SpecMessage.UTTERANCE)
+
+    # -- modernize: legacy producer reaches a spec listener -----------------
+
+    def test_legacy_emit_reaches_spec_listener(self) -> None:
+        """A component emitting a LEGACY topic is received on the ovos.* SPEC
+        topic (modernize bridging)."""
+        bus = FakeBus()  # both flags default on
+        spec_seen = _collect(bus, SPEC_SPEAK)
+
+        bus.emit(Message(LEGACY_SPEAK, {"utterance": "hello"}))
+
+        self.assertEqual(len(spec_seen), 1)
+        self.assertEqual(spec_seen[0].msg_type, SPEC_SPEAK)
+        self.assertEqual(spec_seen[0].data["utterance"], "hello")
+
+    def test_legacy_utterance_reaches_spec_listener(self) -> None:
+        """recognizer_loop:utterance is delivered on ovos.utterance.handle."""
+        bus = FakeBus()
+        spec_seen = _collect(bus, SPEC_UTTERANCE)
+
+        bus.emit(Message(LEGACY_UTTERANCE, {"utterances": ["turn on the light"]}))
+
+        self.assertEqual(len(spec_seen), 1)
+        self.assertEqual(spec_seen[0].data["utterances"], ["turn on the light"])
+
+    # -- emit_legacy: spec producer reaches a legacy listener ---------------
+
+    def test_spec_emit_reaches_legacy_listener(self) -> None:
+        """A component emitting the SPEC topic is received by a LEGACY listener
+        (emit_legacy bridging)."""
+        bus = FakeBus()
+        legacy_seen = _collect(bus, LEGACY_SPEAK)
+
+        bus.emit(Message(SPEC_SPEAK, {"utterance": "goodbye"}))
+
+        self.assertEqual(len(legacy_seen), 1)
+        self.assertEqual(legacy_seen[0].msg_type, LEGACY_SPEAK)
+        self.assertEqual(legacy_seen[0].data["utterance"], "goodbye")
+
+    # -- dedup: a handler on BOTH topics fires once -------------------------
+
+    def test_handler_on_both_topics_fires_once(self) -> None:
+        """A handler subscribed to BOTH the legacy and the spec topic fires once
+        per real event (the mirror is dropped)."""
+        bus = FakeBus()
+        calls = []
+
+        def handler(message=None):
+            calls.append(message.msg_type)
+
+        bus.on(LEGACY_SPEAK, handler)
+        bus.on(SPEC_SPEAK, handler)
+
+        bus.emit(Message(LEGACY_SPEAK, {"utterance": "once"}))
+
+        self.assertEqual(len(calls), 1,
+                         f"dual-subscribed handler fired {len(calls)}x: {calls}")
+
+    def test_two_genuine_events_each_fire(self) -> None:
+        """Dedup must not swallow two genuine events. A SINGLE handler on both
+        topics fires exactly once per real event, never zero."""
+        bus = FakeBus()
+        calls = []
+
+        def handler(message=None):
+            calls.append(message.data.get("utterance"))
+
+        bus.on(LEGACY_SPEAK, handler)
+        bus.on(SPEC_SPEAK, handler)
+
+        bus.emit(Message(LEGACY_SPEAK, {"utterance": "first"}))
+        bus.emit(Message(LEGACY_SPEAK, {"utterance": "second"}))
+
+        # shared mirror-guard dedupes each event's counterpart -> two calls
+        self.assertEqual(calls, ["first", "second"])
+
+    # -- single-namespace isolation (no bridging) ---------------------------
+
+    def test_no_bridging_isolates_namespaces(self) -> None:
+        """FakeBus(modernize=False, emit_legacy=False) keeps each namespace
+        isolated, proving the harness can exercise ONE namespace explicitly."""
+        bus = FakeBus(modernize=False, emit_legacy=False)
+        spec_seen = _collect(bus, SPEC_SPEAK)
+        legacy_seen = _collect(bus, LEGACY_SPEAK)
+
+        bus.emit(Message(LEGACY_SPEAK, {"utterance": "legacy only"}))
+        bus.emit(Message(SPEC_SPEAK, {"utterance": "spec only"}))
+
+        # legacy listener saw only the legacy emit; spec listener only the spec
+        self.assertEqual([m.data["utterance"] for m in legacy_seen], ["legacy only"])
+        self.assertEqual([m.data["utterance"] for m in spec_seen], ["spec only"])
+
+    def test_modernize_only_does_not_emit_legacy(self) -> None:
+        """modernize=True, emit_legacy=False: legacy->spec bridges but spec->legacy
+        does not."""
+        bus = FakeBus(modernize=True, emit_legacy=False)
+        spec_seen = _collect(bus, SPEC_SPEAK)
+        legacy_seen = _collect(bus, LEGACY_SPEAK)
+
+        bus.emit(Message(LEGACY_SPEAK, {"utterance": "x"}))   # bridges -> spec
+        bus.emit(Message(SPEC_SPEAK, {"utterance": "y"}))     # must NOT -> legacy
+
+        self.assertEqual([m.data["utterance"] for m in spec_seen], ["x", "y"])
+        self.assertEqual([m.data["utterance"] for m in legacy_seen], ["x"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_ocp_namespace.py
+++ b/test/unittests/test_ocp_namespace.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Jarbas AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Namespace-bridging tests for the OCP harness (ovoscope.ocp.OCPTest).
+
+OCPTest drives the OCP query flow by emitting the LEGACY
+``recognizer_loop:utterance`` topic into a MiniCroft. These tests pin that the
+harness FakeBus bridges that topic to/from the ovos.* SPEC topic
+(``ovos.utterance.handle``) so an OCP test can deliberately exercise EITHER
+namespace, and that disabling the bridge isolates a single namespace.
+
+The OCP query/response path itself is covered elsewhere; here we assert only the
+namespace plumbing OCPTest threads into the harness, driving the SAME real
+utterance topic OCPTest emits.
+"""
+
+import importlib.util
+import threading
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
+
+from ovoscope.ocp import OCPTest
+
+# OCPTest spins up a full MiniCroft; gate on ovos-core being importable.
+CORE_AVAILABLE = importlib.util.find_spec("ovos_core") is not None
+
+LEGACY_UTTERANCE = "recognizer_loop:utterance"
+SPEC_UTTERANCE = str(SpecMessage.UTTERANCE)  # ovos.utterance.handle
+
+
+class TestOCPTestNamespaceFields(unittest.TestCase):
+    """The bridging flags are exposed on OCPTest and default on (no extra deps)."""
+
+    def test_defaults_on(self) -> None:
+        t = OCPTest(skill_ids=[], utterance="play jazz")
+        self.assertTrue(t.modernize)
+        self.assertTrue(t.emit_legacy)
+
+    def test_flags_settable(self) -> None:
+        t = OCPTest(skill_ids=[], utterance="play jazz",
+                    modernize=False, emit_legacy=False)
+        self.assertFalse(t.modernize)
+        self.assertFalse(t.emit_legacy)
+
+
+@unittest.skipUnless(CORE_AVAILABLE, "ovos-core not installed")
+class TestOCPTestNamespaceBridging(unittest.TestCase):
+    """Drive the real OCP utterance topic on a harness MiniCroft and assert the
+    legacy<->spec bridge OCPTest relies on."""
+
+    def _make_mc(self, **kwargs):
+        from ovoscope import get_minicroft
+        return get_minicroft([], lang="en-US", max_wait=60, **kwargs)
+
+    def _emit_and_collect(self, mc, emit_topic, watch_topic, *, timeout=3.0):
+        seen = []
+        got = threading.Event()
+
+        def _on(msg):
+            if isinstance(msg, str):
+                msg = Message.deserialize(msg)
+            seen.append(msg)
+            got.set()
+
+        mc.bus.on(watch_topic, _on)
+        try:
+            mc.bus.emit(Message(
+                emit_topic,
+                data={"utterances": ["play some jazz"], "lang": "en-US"},
+            ))
+            got.wait(timeout)
+        finally:
+            mc.bus.remove(watch_topic, _on)
+        return seen
+
+    def test_legacy_utterance_observed_on_spec_topic(self) -> None:
+        """Default (bridging on): OCPTest's legacy recognizer_loop:utterance is
+        observed on the spec ovos.utterance.handle topic (modernize)."""
+        mc = self._make_mc()  # modernize/emit_legacy default on
+        try:
+            seen = self._emit_and_collect(mc, LEGACY_UTTERANCE, SPEC_UTTERANCE)
+            self.assertTrue(seen, "legacy utterance was not bridged to the spec topic")
+            self.assertEqual(seen[0].data["utterances"], ["play some jazz"])
+        finally:
+            mc.stop()
+
+    def test_spec_utterance_reaches_legacy_listener(self) -> None:
+        """An utterance emitted on the SPEC topic reaches a LEGACY listener
+        (emit_legacy) — the OCP query path keys off the legacy topic."""
+        mc = self._make_mc()
+        try:
+            seen = self._emit_and_collect(mc, SPEC_UTTERANCE, LEGACY_UTTERANCE)
+            self.assertTrue(seen, "spec utterance was not bridged to the legacy topic")
+            self.assertEqual(seen[0].data["utterances"], ["play some jazz"])
+        finally:
+            mc.stop()
+
+    def test_no_bridging_isolates_legacy_from_spec(self) -> None:
+        """With bridging OFF, a legacy emit does NOT reach a spec-only
+        subscriber — OCPTest(modernize=False, emit_legacy=False) exercises a
+        single namespace."""
+        mc = self._make_mc(modernize=False, emit_legacy=False)
+        try:
+            seen = self._emit_and_collect(mc, LEGACY_UTTERANCE, SPEC_UTTERANCE,
+                                          timeout=0.5)
+            self.assertEqual(seen, [],
+                             "legacy emit must not reach the spec topic when bridging is off")
+        finally:
+            mc.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_phal.py
+++ b/test/unittests/test_phal.py
@@ -235,3 +235,69 @@ class TestPluginFactories:
         )
         captured = t.execute()
         assert any(m.msg_type == "ovos.resp" for m in captured)
+
+
+# ---------------------------------------------------------------------------
+# Namespace bridging
+# ---------------------------------------------------------------------------
+
+try:
+    from ovos_spec_tools import SpecMessage
+    _HAS_SPEC_TOOLS = True
+except ImportError:
+    _HAS_SPEC_TOOLS = False
+
+
+@pytest.mark.skipif(not _HAS_SPEC_TOOLS,
+                    reason="requires ovos-spec-tools (SpecMessage)")
+class TestMiniPHALNamespaceBridging:
+    """PHAL plugins communicate over arbitrary plugin-specific topics and touch
+    NONE of the legacy<->ovos.* migrated topics, so the harness has no migrated
+    topic of its own to drive. These tests instead verify that the harness
+    ``FakeBus`` performs the same namespace bridging as the audio/media harnesses
+    (so a PHAL plugin that *did* consume/produce a migrated topic would
+    interoperate across both namespaces), and that the ``modernize``/``emit_legacy``
+    flags are threaded through ``MiniPHAL`` to that bus.
+    """
+
+    def test_bus_bridges_legacy_to_spec_by_default(self) -> None:
+        """Default harness (bridging on): a LEGACY emit on the harness bus is
+        delivered to a SPEC-topic subscriber (modernize bridging)."""
+        spec_topic = str(SpecMessage.SPEAK)  # ovos.utterance.speak
+        with MiniPHAL() as phal:
+            seen = []
+            phal._bus.on(spec_topic, lambda m: seen.append(m))
+            phal._bus.emit(Message("speak", {"utterance": "hi"}))
+            time.sleep(0.05)
+            assert [m.data["utterance"] for m in seen] == ["hi"]
+
+    def test_bus_bridges_spec_to_legacy_by_default(self) -> None:
+        """Default harness (bridging on): a SPEC emit on the harness bus is
+        delivered to a LEGACY-topic subscriber (emit_legacy bridging)."""
+        spec_topic = str(SpecMessage.SPEAK)
+        with MiniPHAL() as phal:
+            seen = []
+            phal._bus.on("speak", lambda m: seen.append(m))
+            phal._bus.emit(Message(spec_topic, {"utterance": "bye"}))
+            time.sleep(0.05)
+            assert [m.data["utterance"] for m in seen] == ["bye"]
+
+    def test_no_bridging_isolates_namespaces(self) -> None:
+        """With modernize=False, emit_legacy=False the harness bus keeps each
+        namespace isolated — a LEGACY emit does NOT reach a SPEC subscriber."""
+        spec_topic = str(SpecMessage.SPEAK)
+        with MiniPHAL(modernize=False, emit_legacy=False) as phal:
+            seen = []
+            phal._bus.on(spec_topic, lambda m: seen.append(m))
+            phal._bus.emit(Message("speak", {"utterance": "legacy only"}))
+            time.sleep(0.1)
+            assert seen == []
+
+    def test_phal_test_threads_bridging_flags(self) -> None:
+        """PHALTest forwards modernize/emit_legacy to MiniPHAL (default True)."""
+        t = PHALTest(
+            plugin_ids=[],
+            trigger_message=Message("harmless.trigger"),
+        )
+        assert t.modernize is True
+        assert t.emit_legacy is True

--- a/test/unittests/test_pipeline_harness.py
+++ b/test/unittests/test_pipeline_harness.py
@@ -1,10 +1,23 @@
 """Regression tests for ovoscope.pipeline._SinkSkill."""
 
+import importlib.util
+import threading
+import time
+import unittest
+
 import pytest
 
+from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_utils.fakebus import FakeBus
 
-from ovoscope.pipeline import _SinkSkill
+from ovoscope.pipeline import PipelineHarness, _SinkSkill
+
+# PipelineHarness spins up a full MiniCroft pinned to the adapt pipeline.
+ADAPT_AVAILABLE = importlib.util.find_spec("ovos_adapt") is not None
+
+LEGACY_UTTERANCE = "recognizer_loop:utterance"
+SPEC_UTTERANCE = str(SpecMessage.UTTERANCE)  # ovos.utterance.handle
 
 
 class _RecordingBus:
@@ -56,3 +69,70 @@ class TestSinkSkillBusHandling:
         sink = _SinkSkill()
         with pytest.raises(ValueError):
             sink.bus = None
+
+
+# ---------------------------------------------------------------------------
+# TestPipelineHarnessNamespaceBridging
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(ADAPT_AVAILABLE, "ovos-adapt pipeline plugin not installed")
+class TestPipelineHarnessNamespaceBridging(unittest.TestCase):
+    """PipelineHarness injects utterances on the LEGACY topic
+    (``recognizer_loop:utterance``). These tests pin that the harness FakeBus
+    bridges that to/from the ovos.* SPEC topic (``ovos.utterance.handle``) so a
+    pipeline test can drive EITHER namespace, and that disabling the bridge
+    isolates a single namespace.
+    """
+
+    PIPELINE = ["ovos-adapt-pipeline-plugin-high"]
+
+    def _emit_and_collect(self, harness, emit_topic, watch_topic, *, timeout=3.0):
+        """Subscribe on ``watch_topic``, emit one utterance on ``emit_topic``,
+        return the payloads observed on ``watch_topic``."""
+        seen = []
+        got = threading.Event()
+
+        def _on(msg):
+            if isinstance(msg, str):
+                msg = Message.deserialize(msg)
+            seen.append(msg)
+            got.set()
+
+        harness._mc.bus.on(watch_topic, _on)
+        try:
+            harness._mc.bus.emit(Message(
+                emit_topic,
+                data={"utterances": ["turn on the lights"], "lang": "en-US"},
+            ))
+            got.wait(timeout)
+        finally:
+            harness._mc.bus.remove(watch_topic, _on)
+        return seen
+
+    def test_legacy_utterance_observed_on_spec_topic(self):
+        """Default harness (bridging on): an utterance injected on the legacy
+        ``recognizer_loop:utterance`` topic is observed on the spec
+        ``ovos.utterance.handle`` topic (modernize bridging)."""
+        with PipelineHarness(pipeline=self.PIPELINE) as h:
+            seen = self._emit_and_collect(h, LEGACY_UTTERANCE, SPEC_UTTERANCE)
+            self.assertTrue(seen, "legacy utterance was not bridged to the spec topic")
+            self.assertEqual(seen[0].data["utterances"], ["turn on the lights"])
+
+    def test_spec_utterance_drives_pipeline_and_legacy_listener(self):
+        """An utterance injected on the SPEC topic still drives the pipeline
+        (a match is produced) and reaches a LEGACY listener (emit_legacy)."""
+        with PipelineHarness(pipeline=self.PIPELINE) as h:
+            legacy_seen = self._emit_and_collect(h, SPEC_UTTERANCE, LEGACY_UTTERANCE)
+            self.assertTrue(legacy_seen,
+                            "spec utterance was not bridged to the legacy topic")
+            self.assertEqual(legacy_seen[0].data["utterances"], ["turn on the lights"])
+
+    def test_no_bridging_isolates_legacy_from_spec(self):
+        """With bridging OFF, a legacy utterance emit does NOT reach a
+        spec-only subscriber — a single namespace is exercised in isolation."""
+        with PipelineHarness(pipeline=self.PIPELINE,
+                             modernize=False, emit_legacy=False) as h:
+            seen = self._emit_and_collect(h, LEGACY_UTTERANCE, SPEC_UTTERANCE,
+                                          timeout=0.5)
+            self.assertEqual(seen, [],
+                             "legacy emit must not reach the spec topic when bridging is off")

--- a/test/unittests/test_simple_listener.py
+++ b/test/unittests/test_simple_listener.py
@@ -13,11 +13,29 @@
 # limitations under the License.
 """Unit tests for the MiniSimpleListener harness (ovos-simple-listener)."""
 import io
+import time
 import unittest
 import wave
 
+from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
+
 from ovoscope.simple_listener import MiniSimpleListener
 from ovoscope.voice_loop import MockHotWordEngine, MockStreamingSTT
+
+def _mic_available() -> bool:
+    """SimpleListener eagerly builds a real microphone in __init__ (mic=None),
+    so the harness can only be constructed when a microphone plugin is present.
+    """
+    try:
+        from ovos_plugin_manager.microphone import OVOSMicrophoneFactory
+        OVOSMicrophoneFactory.create()
+        return True
+    except Exception:
+        return False
+
+
+HAS_MIC = _mic_available()
 
 try:
     import ovos_simple_listener  # noqa: F401
@@ -72,6 +90,78 @@ class TestMiniSimpleListener(unittest.TestCase):
         ) as sl:
             sl.feed_file(_wav(), silence_tail_chunks=20)
             sl.assert_record_begin_emitted()
+
+
+# ---------------------------------------------------------------------------
+# TestMiniSimpleListenerNamespaceBridging
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(HAS_SIMPLE, "ovos-simple-listener not installed")
+@unittest.skipUnless(HAS_MIC, "no ovos microphone plugin available")
+class TestMiniSimpleListenerNamespaceBridging(unittest.TestCase):
+    """The _SimpleBusCallbacks emit the LEGACY ``recognizer_loop:*`` topics;
+    ``record_begin``/``record_end``/``utterance`` are migrated to the ovos.*
+    spec namespace.  These tests pin that the FakeBus namespace bridging
+    connects the two namespaces, and that turning it off isolates one.
+    """
+
+    def test_full_sequence_legacy_reaches_spec_via_bridging(self):
+        """Default harness (bridging on): the legacy record-begin/record-end/
+        utterance emitted while running the listener are also delivered to
+        subscribers on the spec topics."""
+        with MiniSimpleListener(
+            wakeword=MockHotWordEngine("hey_mycroft", trigger_after=2),
+            stt_instance=MockStreamingSTT(transcript="turn on the lights"),
+        ) as sl:
+            spec = {"begin": [], "end": [], "utt": []}
+            sl.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED),
+                      lambda m: spec["begin"].append(m))
+            sl.bus.on(str(SpecMessage.LISTENER_RECORD_ENDED),
+                      lambda m: spec["end"].append(m))
+            sl.bus.on(str(SpecMessage.UTTERANCE),
+                      lambda m: spec["utt"].append(m))
+
+            msgs = sl.feed_file(_wav(), silence_tail_chunks=20)
+            time.sleep(0.05)
+            legacy_types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:record_begin", legacy_types)
+            self.assertTrue(spec["begin"],
+                            "ovos.listener.record.started not seen via bridge")
+            self.assertTrue(spec["end"],
+                            "ovos.listener.record.ended not seen via bridge")
+            self.assertTrue(spec["utt"],
+                            "ovos.utterance.handle not seen via bridge")
+
+    def test_record_begin_spec_native(self):
+        """A SPEC producer reaches a spec subscriber natively."""
+        with MiniSimpleListener(
+            wakeword=MockHotWordEngine("hey_mycroft", trigger_after=2),
+        ) as sl:
+            spec_hits = []
+            sl.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED),
+                      lambda m: spec_hits.append(m))
+            sl.bus.emit(Message(str(SpecMessage.LISTENER_RECORD_STARTED)))
+            time.sleep(0.05)
+            self.assertTrue(spec_hits,
+                            "ovos.listener.record.started not delivered natively")
+
+    def test_no_bridging_isolates_legacy_from_spec(self):
+        """With bridging OFF, a legacy record-begin does NOT reach a spec-only
+        subscriber."""
+        with MiniSimpleListener(
+            wakeword=MockHotWordEngine("hey_mycroft", trigger_after=2),
+            modernize=False, emit_legacy=False,
+        ) as sl:
+            legacy_hits, spec_hits = [], []
+            sl.bus.on("recognizer_loop:record_begin",
+                      lambda m: legacy_hits.append(m))
+            sl.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED),
+                      lambda m: spec_hits.append(m))
+            sl.bus.emit(Message("recognizer_loop:record_begin"))
+            time.sleep(0.1)
+            self.assertTrue(legacy_hits, "legacy record_begin should still fire")
+            self.assertEqual(spec_hits, [],
+                             "spec topic must not fire with bridging off")
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_voice_loop.py
+++ b/test/unittests/test_voice_loop.py
@@ -20,9 +20,13 @@ TestVoiceLoopTest         — declarative helper
 """
 import inspect
 import io
+import time
 import unittest
 import wave
 from unittest.mock import Mock
+
+from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 
 from ovoscope.voice_loop import (
     MiniHotwordContainer,
@@ -296,6 +300,77 @@ class TestVoiceLoopTest(unittest.TestCase):
             audio_file=_wav(),
             expect_utterance="hello world",
         ).execute()
+
+
+# ---------------------------------------------------------------------------
+# TestMiniVoiceLoopNamespaceBridging
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(HAS_DINKUM, "ovos-dinkum-listener not installed")
+class TestMiniVoiceLoopNamespaceBridging(unittest.TestCase):
+    """The MiniVoiceLoop callbacks emit the LEGACY ``recognizer_loop:*`` topics;
+    ``record_begin``/``record_end``/``utterance`` are migrated to the ovos.*
+    spec namespace.  These tests pin that the FakeBus namespace bridging
+    connects the two namespaces, and that turning it off isolates one.
+    """
+
+    def test_full_loop_legacy_reaches_spec_via_bridging(self):
+        """Default loop (bridging on): the legacy record-begin/record-end/
+        utterance emitted while driving the full loop are also delivered to
+        subscribers on the spec topics."""
+        with MiniVoiceLoop(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=2)},
+            stt_instance=MockStreamingSTT(transcript="hello world"),
+        ) as vl:
+            spec = {"begin": [], "end": [], "utt": []}
+            vl.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED),
+                      lambda m: spec["begin"].append(m))
+            vl.bus.on(str(SpecMessage.LISTENER_RECORD_ENDED),
+                      lambda m: spec["end"].append(m))
+            vl.bus.on(str(SpecMessage.UTTERANCE),
+                      lambda m: spec["utt"].append(m))
+
+            msgs = vl.feed_file(_wav())
+            time.sleep(0.05)
+            legacy_types = [m.msg_type for m in msgs]
+            self.assertIn("recognizer_loop:record_begin", legacy_types)
+            self.assertTrue(spec["begin"],
+                            "ovos.listener.record.started not seen via bridge")
+            self.assertTrue(spec["end"],
+                            "ovos.listener.record.ended not seen via bridge")
+            self.assertTrue(spec["utt"],
+                            "ovos.utterance.handle not seen via bridge")
+
+    def test_record_begin_spec_native(self):
+        """A SPEC producer reaches a spec subscriber natively."""
+        with MiniVoiceLoop(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=2)},
+        ) as vl:
+            spec_hits = []
+            vl.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED),
+                      lambda m: spec_hits.append(m))
+            vl.bus.emit(Message(str(SpecMessage.LISTENER_RECORD_STARTED)))
+            time.sleep(0.05)
+            self.assertTrue(spec_hits,
+                            "ovos.listener.record.started not delivered natively")
+
+    def test_no_bridging_isolates_legacy_from_spec(self):
+        """With bridging OFF, a legacy record-begin does NOT reach a spec-only
+        subscriber."""
+        with MiniVoiceLoop(
+            ww_instances={"hey_mycroft": MockHotWordEngine(trigger_after=2)},
+            modernize=False, emit_legacy=False,
+        ) as vl:
+            legacy_hits, spec_hits = [], []
+            vl.bus.on("recognizer_loop:record_begin",
+                      lambda m: legacy_hits.append(m))
+            vl.bus.on(str(SpecMessage.LISTENER_RECORD_STARTED),
+                      lambda m: spec_hits.append(m))
+            vl.bus.emit(Message("recognizer_loop:record_begin"))
+            time.sleep(0.1)
+            self.assertTrue(legacy_hits, "legacy record_begin should still fire")
+            self.assertEqual(spec_hits, [],
+                             "spec topic must not fire with bridging off")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Companion to **OpenVoiceOS/ovos-audio#165**. Migrates the audio test harnesses to the OVOS spec bus namespace via \`SpecMessage\` so they keep driving/observing ovos-audio after its spec-bus migration.

The harnesses run on a plain \`FakeBus\` (no \`modernize\` bridging), so they must emit and observe the \`ovos.*\` spec topics directly:
- \`PlaybackServiceHarness.speak()\` emits \`SpecMessage.SPEAK\` (\`ovos.utterance.speak\`).
- Lifecycle subscriptions + \`AudioCaptureSession\` capture \`SpecMessage.AUDIO_OUTPUT_STARTED\` / \`AUDIO_OUTPUT_ENDED\` / \`MIC_LISTEN\`.
- \`AudioServiceHarness\` ducking wiring on the spec output topics.

\`pyproject.toml\`: \`audio\`/\`tts\` extras bumped to the spec-migrated \`ovos-audio\` and an explicit \`ovos-spec-tools>=0.9.0a1\` added (the harness imports \`SpecMessage\`).

## Stacked / CI
Depends on the spec-migrated ovos-audio (#165) + unpublished ovos-spec-tools/ovos-bus-client alphas. CI stays red until those publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable legacy/spec topic bridging across the harness, with new options to enable or isolate cross-namespace message flow.
  * Expanded test support to cover both legacy and modern event topics in audio, listener, voice loop, OCP, PHAL, and pipeline scenarios.
  * Added broader namespace-bridging coverage for end-to-end and unit tests.

* **Bug Fixes**
  * Improved message handling so events are observed consistently across legacy and modern topic names.
  * Updated capture and assertion behavior to recognize either namespace during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->