### PR TITLE
fix: guard None blacklisted_skills/intents in final-session check

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -941,8 +941,8 @@ class End2EndTest:
             assert sess.time_format == expected_sess.time_format, f"❌ final session time_format doesn't match"
             assert sess.site_id == expected_sess.site_id, f"❌ final session site_id doesn't match"
             assert sess.session_id == expected_sess.session_id, f"❌ final session session_id doesn't match"
-            assert set(sess.blacklisted_skills) == set(expected_sess.blacklisted_skills), f"❌ final session blacklisted_skills doesn't match"
-            assert set(sess.blacklisted_intents) == set(expected_sess.blacklisted_intents), f"❌ final session blacklisted_intents doesn't match"
+            assert set(sess.blacklisted_skills or []) == set(expected_sess.blacklisted_skills or []), f"❌ final session blacklisted_skills doesn't match"
+            assert set(sess.blacklisted_intents or []) == set(expected_sess.blacklisted_intents or []), f"❌ final session blacklisted_intents doesn't match"
             if self.verbose:
                 print(f"✅ final session matches: {expected_sess.serialize()}")
 


### PR DESCRIPTION
Under the 9.x session shape, `Session.blacklisted_skills` and `blacklisted_intents` can be `None` rather than an empty list. The final-session equality check in `HiveMessageScope`/`MiniCroftScope` then raised `TypeError: 'NoneType' object is not iterable` at `ovoscope/__init__.py:944`.

Coalesce both to `[]` before `set()` so the assertion compares cleanly. Surfaced by the ovos-core spec-conformance e2e suite (PR #765) against the integrated workshop-9.x stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test checks so empty or missing blacklisted skills and intents are handled correctly.
  * Reduced false failures when session data is absent by treating missing values as empty lists during comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->