### PR TITLE
fix: MockTTS destructor must not stop the shared playback thread

### DIFF
--- a/ovoscope/audio.py
+++ b/ovoscope/audio.py
@@ -512,6 +512,26 @@ class MockTTS(TTS):
         """Clear the list of recorded spoken utterances."""
         self.spoken_utterances.clear()
 
+    def __del__(self) -> None:
+        """No-op destructor.
+
+        ``TTS.__del__`` chains into ``TTS.shutdown() -> TTS.stop() ->
+        TTS.playback.stop()``. ``TTS.playback`` is a **class-level** attribute
+        shared by every TTS instance in the process, so when an earlier
+        harness's MockTTS is garbage-collected its inherited destructor stops
+        whatever PlaybackThread is *currently* registered there — which, by
+        then, belongs to a later, still-running harness. The victim thread sets
+        ``_terminated`` and exits mid-run, so its queued speak never plays and
+        ``ovos.audio.output.ended`` is never emitted, hanging the next
+        ``speak()`` wait.
+
+        GC timing is nondeterministic, so the failure surfaces as a flaky
+        ``TimeoutError`` only after several harness instances have been created
+        and collected. The harness already manages thread lifecycle explicitly
+        via ``PlaybackService.shutdown()`` on context exit, so a MockTTS
+        instance must never tear down the shared playback thread on collection.
+        """
+
 
 # ---------------------------------------------------------------------------
 # PlaybackServiceHarness

--- a/test/unittests/test_audio_harness.py
+++ b/test/unittests/test_audio_harness.py
@@ -34,6 +34,7 @@ from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 
 if AUDIO_AVAILABLE:
+    from ovos_plugin_manager.templates.tts import TTS
     from ovoscope.audio import (
         AudioCaptureSession,
         AudioServiceHarness,
@@ -491,6 +492,79 @@ class TestAudioHarnessNamespaceBridging(unittest.TestCase):
             h.speak("namespace test")
             h.assert_audio_output_started()
             h.assert_audio_output_ended()
+
+
+@unittest.skipUnless(AUDIO_AVAILABLE, "ovos-audio (audio extra) not installed")
+class TestPlaybackServiceHarnessIsolation(unittest.TestCase):
+    """Repeated, independent harness instances must not interfere.
+
+    Regression for the shared ``TTS.playback`` class-attribute hazard: a
+    garbage-collected MockTTS from an earlier harness used to stop the
+    PlaybackThread of a *later*, still-running harness (via the inherited
+    ``TTS.__del__`` -> ``TTS.stop`` -> ``TTS.playback.stop()`` chain). The
+    victim thread terminated mid-run, its queued speak never played, and the
+    next ``speak()`` hung until timeout. Because GC timing is nondeterministic
+    this manifested as a flaky ``TimeoutError`` only after several
+    create/destroy cycles.
+    """
+
+    def test_many_sequential_harnesses_each_complete_speaks(self) -> None:
+        """Boot and tear down many harnesses, forcing GC between them, and
+        require every speak in every harness to complete deterministically."""
+        import gc
+
+        for i in range(12):
+            with PlaybackServiceHarness() as h:
+                for tag in ("a", "b", "c"):
+                    # unique sentences so the persistent TTS cache never
+                    # short-circuits synthesis — each must drive real playback
+                    h.speak(f"iter {i} part {tag}", timeout=8.0)
+                    self.assertIn(f"iter {i} part {tag}",
+                                  h.mock_tts.spoken_utterances)
+            # provoke collection of the just-exited MockTTS *now*, while a
+            # fresh harness will shortly own TTS.playback. Pre-fix, this is
+            # exactly what killed the next harness's playback thread.
+            gc.collect()
+
+    def test_stale_mock_destructor_does_not_kill_live_thread(self) -> None:
+        """A finished harness's MockTTS destructor must not terminate the
+        playback thread that a *later* harness now owns.
+
+        Deterministic reproduction of the GC race: keep a reference to harness
+        A's MockTTS so it outlives A, open harness B (which registers its own
+        thread on the shared ``TTS.playback`` class attribute), then run A's
+        destructor. Pre-fix, ``MockTTS.__del__`` chained into
+        ``TTS.playback.stop()`` and terminated B's live thread; B's next speak
+        would then hang. With the no-op destructor, B is unaffected.
+        """
+        # Harness A — produce a MockTTS that survives the context exit.
+        with PlaybackServiceHarness() as ha:
+            ha.speak("harness A warmup", timeout=8.0)
+        stale_mock = ha.mock_tts
+
+        # Harness B now owns the shared TTS.playback thread.
+        with PlaybackServiceHarness() as hb:
+            self.assertIs(TTS.playback, hb.svc.playback_thread)
+            self.assertTrue(hb.svc.playback_thread.is_alive())
+
+            # Fire harness A's destructor explicitly (what GC would do).
+            stale_mock.__del__()
+
+            # The precise invariant: A's destructor must not have flagged B's
+            # thread for termination. ``_terminated`` is checked at the top of
+            # the playback loop, so a single in-flight speak can still slip
+            # through even when set — but the thread would then exit on its next
+            # iteration, hanging a subsequent speak. Assert the flag directly.
+            self.assertFalse(
+                hb.svc.playback_thread._terminated,
+                "stale MockTTS destructor terminated the live playback thread",
+            )
+
+            # And B must keep working across multiple speaks (the loop must not
+            # have exited).
+            for n in range(3):
+                hb.speak(f"harness B speak {n}", timeout=8.0)
+            self.assertTrue(hb.svc.playback_thread.is_alive())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`TTS.playback` is a **class-level** attribute shared by every TTS instance in the process. The inherited `TTS.__del__` chains into `TTS.shutdown() -> TTS.stop() -> TTS.playback.stop()`. So when an earlier `PlaybackServiceHarness`'s `MockTTS` is garbage-collected, its destructor stops whatever `PlaybackThread` is **currently** registered there — which, by then, belongs to a **later, still-running harness**.

The victim thread gets `_terminated` set and exits its run loop, so its queued speak never plays and `ovos.audio.output.ended` is never emitted. The next `speak()` then hangs until timeout. Because GC timing is nondeterministic, this surfaced as a **flaky `TimeoutError`** only after several harness create/destroy cycles.

This was caught when ovos-audio wired up the `ovoscope` CI job (OpenVoiceOS/ovos-audio#171): its `test/end2end/` suite went red with `TimeoutError: Speech playback for '...' did not finish within 10.0s` at `ovoscope/audio.py` (the `speak()` wait), on pre-existing tests that simply do 2+ speaks per harness after enough preceding harnesses.

### Root cause (traced)

```
TTS.__del__  ->  TTS.shutdown  ->  TTS.stop  ->  TTS.playback.stop()   # class-level!
```

At the stall, the active harness's `playback_thread.is_alive() == False` / `_terminated == True`, with a speak item still queued and no live consumer.

## Fix

Override `MockTTS.__del__` as a no-op. The harness already manages the playback-thread lifecycle explicitly via `PlaybackService.shutdown()` on context exit, so a mock instance must never tear down the shared thread on collection.

## Tests

- `test_stale_mock_destructor_does_not_kill_live_thread` — deterministic guard: fire a stale mock's destructor while a later harness owns `TTS.playback`; assert the live thread is neither `_terminated` nor unable to keep speaking. **Fails on `dev`, passes with the fix.**
- `test_many_sequential_harnesses_each_complete_speaks` — many create/destroy cycles with forced GC; every speak must complete.

### Verification

| | ovos-audio `test/end2end/test_playback_service_extended_e2e.py` |
|---|---|
| dev (unfixed) | `1 failed, 12 passed` (3/3 runs) |
| this PR | `13 passed` (3/3 runs) |

Full `ovoscope` audio harness unit suite: `44 passed`. Full ovos-audio `test/end2end/`: `57 passed` (was `2 failed, 55 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback reliability by preventing cleanup from stopping active playback in later sessions.
  * Reduced flaky timeouts when using audio features across repeated start/stop cycles.

* **Tests**
  * Added regression coverage for repeated playback lifecycle scenarios and stale-object cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->