### PR TITLE
docs: clarify MockTTS bus.ee.emit rationale

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -393,12 +393,19 @@ class MiniCroft(SkillManager):
                       emit_legacy=self._emit_legacy)
         bus.on("message", self.handle_boot_message)
 
-        # TTS mock: speak_dialog(…, wait=True) blocks on
-        # recognizer_loop:audio_output_end. Since there is no real TTS we
-        # schedule a short-delay emit to unblock the handler.
-        # This uses bus.ee.emit (not bus.emit) to bypass FakeBus's
-        # namespace-migration and on_message side effects so the synthetic
-        # event does not appear in test captures or reset session state.
+        # TTS mock: speak_dialog(…, wait=True) blocks in wait_while_speaking on
+        # recognizer_loop:audio_output_end. With no real TTS that event never
+        # arrives, so the handler stalls until the dispatcher's §8.3 timeout. We
+        # schedule a short-delay emit to unblock it.
+        #
+        # Deliberately bus.ee.emit, NOT bus.emit: audio_output_end is a synthetic
+        # *hardware/audio* event, not a message a component emitted with an
+        # authoritative session. bus.emit would run FakeBus.on_message, which —
+        # like the real MessageBusClient — rebuilds the Session from the message and
+        # calls SessionManager.update(), wholesale-replacing the cached session. A
+        # contentless synthetic event would thereby clobber transient state
+        # (is_speaking, active_skills). bus.ee.emit fires only the topic handlers,
+        # which is the correct semantics for injecting a fake audio event.
         def _mock_tts(message):
             sess = SessionManager.get(message)
             threading.Timer(0.1, lambda: bus.ee.emit(


### PR DESCRIPTION
Expands the MockTTS comment to document why it uses `bus.ee.emit` (synthetic audio event must not trigger `FakeBus.on_message`'s session rebuild, which mirrors the real `MessageBusClient` and would clobber transient session state). Comment-only.

Also serves as the merge that re-triggers a release now that gh-automations#64 fixed the `uv: command not found` publish failure — so ovoscope finally publishes with MockTTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified an internal note about text-to-speech mock behavior, making the event flow and audio-event handling easier to understand for maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->