### PR TITLE
feat: MockTTS publishes audio_output_end via the full bus (faithful)

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -398,18 +398,20 @@ class MiniCroft(SkillManager):
         # arrives, so the handler stalls until the dispatcher's §8.3 timeout. We
         # schedule a short-delay emit to unblock it.
         #
-        # Deliberately bus.ee.emit, NOT bus.emit: audio_output_end is a synthetic
-        # *hardware/audio* event, not a message a component emitted with an
-        # authoritative session. bus.emit would run FakeBus.on_message, which —
-        # like the real MessageBusClient — rebuilds the Session from the message and
-        # calls SessionManager.update(), wholesale-replacing the cached session. A
-        # contentless synthetic event would thereby clobber transient state
-        # (is_speaking, active_skills). bus.ee.emit fires only the topic handlers,
-        # which is the correct semantics for injecting a fake audio event.
+        # Full bus.emit, like the real audio service: recognizer_loop:audio_output_end
+        # is a genuine bus message in production, so the harness publishes it the
+        # same way — through on_message (namespace migration + capture), where any
+        # bus observer would see it. SessionManager.handle_audio_output_end then
+        # flips is_speaking=False on the one live session object the ovos-bus-client
+        # SessionManager singleton keeps per id, so every holder of that session sees
+        # it. Capture position is faithful: with speak(wait=False) the handler emits
+        # its end-marker first, so this lands after the EOF and is not captured; with
+        # speak(wait=True) the handler blocks in wait_while_speaking until this
+        # arrives, so it deterministically precedes the end-marker and is captured —
+        # exactly as a real deployment would record it.
         def _mock_tts(message):
             sess = SessionManager.get(message)
-            threading.Timer(0.1, lambda: bus.ee.emit(
-                "recognizer_loop:audio_output_end",
+            threading.Timer(0.1, lambda: bus.emit(
                 Message("recognizer_loop:audio_output_end",
                         context={"session": sess.serialize()})
             )).start()


### PR DESCRIPTION
Follow-up to the ovos-bus-client SessionManager singleton (bus-client #249, published 2.6.1a1).

`recognizer_loop:audio_output_end` is a **real bus message** in production (the audio service emits it). The harness now publishes it the same way — plain `bus.emit` through `on_message` — instead of `bus.ee.emit`, which bypassed namespace migration and the capture path. As argued in review: it *should* be recorded, because any real bus observer would record it.

**Why this is now safe** (it wasn't before the singleton): `SessionManager` keeps one live `Session` per id and mutates it in place, so routing through `on_message` no longer wholesale-replaces / clobbers transient session state. `handle_audio_output_end` flips `is_speaking=False` on the shared singleton (verified empirically).

**Capture position is faithful and deterministic:**
- `speak(wait=False)` (all current e2e skills): handler emits its end-marker first → `audio_output_end` lands *after* the EOF → not captured. **No expectation changes** for existing tests.
- `speak(wait=True)`: handler blocks in `wait_while_speaking` until it arrives → it precedes the end-marker → captured, exactly as a real deployment records it.

No current ovoscope self-test or downstream core e2e uses `wait=True`, so captured sequences are unchanged today; the event is correctly recorded for future `wait=True` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)