### PR TITLE
feat: add a pipeline_id filter to End2EndTest

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -731,6 +731,13 @@ class End2EndTest:
     # dispatch and the interrupted skill's own completion race). Run the same
     # scenario once per skill_id to assert each lifecycle deterministically.
     skill_id: Optional[str] = None
+    # Like skill_id, but isolates a lifecycle by its producing pipeline_id
+    # (OVOS-PIPELINE-1 §3.1, stamped on the dispatch context). Use this when the
+    # dispatch and a concurrent lifecycle share a skill_id — e.g. a targeted stop
+    # whose Match.skill_id IS the interrupted skill (OVOS-STOP-1 §3.1): both carry
+    # that skill_id, but only the stop dispatch carries the stop plugin's
+    # pipeline_id. Applied together with skill_id when both are set.
+    pipeline_id: Optional[str] = None
     ignore_gui: bool = True # ignore the gui namespace bus messages, usually unwanted unless explicitly testing gui integration
     async_messages: List[str] = dataclasses.field(default_factory=list) # these come from an external thread and might come in any order, validate they are received outside the main test
 
@@ -863,6 +870,11 @@ class End2EndTest:
                         if (m.context or {}).get("skill_id") == self.skill_id]
             if self.verbose:
                 print(f"💡 filtered to skill_id='{self.skill_id}': {len(messages)} messages")
+        if self.pipeline_id is not None:
+            messages = [m for m in messages
+                        if (m.context or {}).get("pipeline_id") == self.pipeline_id]
+            if self.verbose:
+                print(f"💡 filtered to pipeline_id='{self.pipeline_id}': {len(messages)} messages")
 
         if _bus_tracker is not None:
             _bus_tracker.stop_tracking()
@@ -937,7 +949,7 @@ class End2EndTest:
                     assert received.context[k] == v, f"❌ message context mismatch for key '{k}' - expected '{v}' | got '{received.context[k]}'"
                     if self.verbose:
                         print(f"✅ got expected message context '{k}: '{v}'")
-            if self.test_routing and self.skill_id is None:
+            if self.test_routing and self.skill_id is None and self.pipeline_id is None:
                 r_src = received.context.get("source")
                 r_dst = received.context.get("destination")
                 if expected.msg_type in self.keep_original_src:

--- a/test/unittests/test_end2end_extended.py
+++ b/test/unittests/test_end2end_extended.py
@@ -65,6 +65,25 @@ class TwoLifecycleSkill(OVOSSkill):
             self.bus.emit(Message("ovos.utterance.handled", context=ctx))
 
 
+class SharedSkillIdSkill(OVOSSkill):
+    """Emits two lifecycles that share a context skill_id but differ in
+    pipeline_id — the shape produced when a targeted stop (OVOS-STOP-1 §3.1)
+    interrupts a running skill: both carry the target's skill_id, only the stop
+    dispatch carries the stop plugin's pipeline_id. Exercises the pipeline_id
+    filter. Each lifecycle ends on the shared ``ovos.utterance.handled``."""
+
+    def initialize(self):
+        self.add_event("unittest.shared_skill_id", self.handle_shared)
+
+    def handle_shared(self, message: Message):
+        for pid in ("pipe.a", "pipe.b"):
+            ctx = dict(message.context)
+            ctx["skill_id"] = "shared.skill"
+            ctx["pipeline_id"] = pid
+            self.bus.emit(Message(f"{pid}.step", context=ctx))
+            self.bus.emit(Message("ovos.utterance.handled", context=ctx))
+
+
 def _session(sid="ext-test", pipeline=None):
     s = Session(sid)
     s.lang = "en-US"
@@ -997,6 +1016,63 @@ class TestMessageCountVerbose(unittest.TestCase):
         )
         with self.assertRaises(AssertionError):
             test.execute(timeout=10)
+
+
+class TestPipelineIdFilter(unittest.TestCase):
+    """The pipeline_id filter isolates a lifecycle when a shared skill_id can't."""
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+        self.mc = get_minicroft([SKILL_ID],
+                                extra_skills={SKILL_ID: SharedSkillIdSkill})
+
+    def tearDown(self):
+        self.mc.stop()
+        LOG.set_level("CRITICAL")
+
+    def _common_kwargs(self):
+        return dict(
+            minicroft=self.mc,
+            skill_ids=[SKILL_ID],
+            eof_msgs=["ovos.utterance.handled"],
+            eof_count=2,
+            test_routing=False,
+            test_active_skills=False,
+            test_final_session=False,
+            ignore_messages=DEFAULT_IGNORED + HANDLER_LIFECYCLE,
+            verbose=False,
+        )
+
+    def test_pipeline_id_isolates_when_skill_id_shared(self):
+        # both lifecycles share skill_id="shared.skill"; only pipeline_id differs
+        src = _make_custom("unittest.shared_skill_id")
+        test = End2EndTest(
+            source_message=src,
+            pipeline_id="pipe.a",
+            expected_messages=[
+                Message("pipe.a.step", {},
+                        {"skill_id": "shared.skill", "pipeline_id": "pipe.a"}),
+                Message("ovos.utterance.handled", {},
+                        {"skill_id": "shared.skill", "pipeline_id": "pipe.a"}),
+            ],
+            **self._common_kwargs(),
+        )
+        test.execute(timeout=10)
+
+    def test_pipeline_id_filters_the_other(self):
+        src = _make_custom("unittest.shared_skill_id")
+        test = End2EndTest(
+            source_message=src,
+            pipeline_id="pipe.b",
+            expected_messages=[
+                Message("pipe.b.step", {},
+                        {"skill_id": "shared.skill", "pipeline_id": "pipe.b"}),
+                Message("ovos.utterance.handled", {},
+                        {"skill_id": "shared.skill", "pipeline_id": "pipe.b"}),
+            ],
+            **self._common_kwargs(),
+        )
+        test.execute(timeout=10)
 
 
 class TestSkillIdFilter(unittest.TestCase):


### PR DESCRIPTION
The `skill_id` filter isolates one dispatch lifecycle from concurrent ones by
context `skill_id`. That breaks when two concurrent lifecycles **share** a
skill_id — notably a targeted stop (OVOS-STOP-1 §3.1) interrupting a running
skill: the stop dispatch carries the *target's* skill_id (so it can't be told
apart from the skill's own messages), but only the stop dispatch carries the
stop plugin's `pipeline_id` (OVOS-PIPELINE-1 §3.1, stamped on the dispatch
context).

Adds a `pipeline_id` filter alongside `skill_id` (applied the same way, and
composable). 2 new tests via a skill that emits two lifecycles sharing a
skill_id but differing in pipeline_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * End-to-end test runs can now be isolated by pipeline identifier as well as skill identifier.
  * Message capture now respects the selected pipeline, making it easier to focus on one execution flow when multiple run at once.

* **Bug Fixes**
  * Routing checks are skipped when pipeline isolation is enabled, preventing unrelated assertions from failing during filtered test runs.
  * Added coverage for concurrent executions that share the same skill identifier but belong to different pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->