### PR TITLE
fix: collapse legacy<->ovos.* namespace mirror in captured message stream

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -33,6 +33,29 @@ DEFAULT_KEEP_SRC = ["ovos.skills.fallback.ping"]
 DEFAULT_ACTIVATION = []
 DEFAULT_DEACTIVATION = ["intent.service.skills.deactivate"]
 
+
+def _namespace_mirror_pairs() -> Dict[str, str]:
+    """Bidirectional legacy<->ovos.* topic map from the spec MIGRATION_MAP.
+
+    Maps each migrated topic to its counterpart in the OTHER namespace so a
+    captured message can be recognised as the transparent mirror of the one
+    before it. Empty if ovos-spec-tools does not ship a MIGRATION_MAP.
+    """
+    pairs: Dict[str, str] = {}
+    try:
+        from ovos_spec_tools.messages import MIGRATION_MAP
+    except ImportError:
+        return pairs
+    for legacy, spec in MIGRATION_MAP.items():
+        spec = str(spec)
+        pairs[legacy] = spec
+        pairs[spec] = legacy
+    return pairs
+
+
+# Bidirectional legacy<->ovos.* topic map, computed once at import.
+NAMESPACE_MIRROR_PAIRS: Dict[str, str] = _namespace_mirror_pairs()
+
 # ---------------------------------------------------------------------------
 # Pipeline stage groups — combine as needed for test scenarios
 # ---------------------------------------------------------------------------
@@ -663,9 +686,28 @@ class CaptureSession:
     eof_count: int = 1
     ignore_messages: List[str] = dataclasses.field(default_factory=lambda: DEFAULT_IGNORED)
     async_messages: List[str] = dataclasses.field(default_factory=list) # these come from an external thread and might come in any order
+    # Under the legacy<->ovos.* namespace migration a single logical event may
+    # reach the bus on BOTH namespaces (a dual-emitting spec-adopting producer,
+    # or a bridge that mirrors the firehose): e.g. "speak" and its counterpart
+    # "ovos.utterance.speak". Counting both would double a sequence assertion
+    # written against one namespace. When True, a captured message that is the
+    # namespace mirror of the immediately-preceding captured one (same payload)
+    # is dropped, so the stream carries each logical message once. Distinct
+    # events are untouched — only an adjacent, payload-equal mirror collapses.
+    collapse_namespace_mirrors: bool = True
     done: threading.Event = dataclasses.field(default_factory=lambda: threading.Event())
     _eof_lock: threading.Lock = dataclasses.field(default_factory=lambda: threading.Lock())
     _eof_seen: int = 0
+
+    def _is_mirror_of_last(self, msg: Message) -> bool:
+        """True if ``msg`` is the transparent namespace mirror of the last
+        captured response — its migration counterpart topic carrying the same
+        payload — and so should not be counted as a second logical message."""
+        if not self.responses:
+            return False
+        prev = self.responses[-1]
+        counterpart = NAMESPACE_MIRROR_PAIRS.get(msg.msg_type)
+        return counterpart == prev.msg_type and msg.data == prev.data
 
     def handle_message(self, msg: str):
         if self.done.is_set():
@@ -674,6 +716,8 @@ class CaptureSession:
         if msg.msg_type in self.async_messages:
             self.async_responses.append(msg)
         elif msg.msg_type not in self.ignore_messages:
+            if self.collapse_namespace_mirrors and self._is_mirror_of_last(msg):
+                return
             self.responses.append(msg)
 
     def handle_end_of_test(self, msg: Message):
@@ -723,6 +767,11 @@ class End2EndTest:
     eof_msgs: List[str] = dataclasses.field(default_factory=lambda: DEFAULT_EOF) # if received, end message capture
     eof_count: int = 1 # end capture only after an eof message has been seen this many times (one per concurrent lifecycle terminating on the same topic)
     ignore_messages: List[str] = dataclasses.field(default_factory=lambda: DEFAULT_IGNORED) # pretend any message in this list was not emitted for testing purposes
+    # Collapse a captured message that is the transparent legacy<->ovos.* namespace
+    # mirror of the one before it (same payload) so a sequence authored against a
+    # single namespace is not doubled by the migration dual-send. Set False to
+    # assert BOTH namespaces explicitly.
+    collapse_namespace_mirrors: bool = True
     # Assert only the messages belonging to a single dispatch lifecycle, identified
     # by message.context["skill_id"]. When set, captured messages whose skill_id does
     # not match are dropped before assertion. This isolates one lifecycle's §8 trio +
@@ -853,7 +902,8 @@ class End2EndTest:
         capture = CaptureSession(self.minicroft, eof_msgs=self.eof_msgs,
                                  eof_count=self.eof_count,
                                  ignore_messages=self.ignore_messages,
-                                 async_messages=self.async_messages)
+                                 async_messages=self.async_messages,
+                                 collapse_namespace_mirrors=self.collapse_namespace_mirrors)
         for idx, source_message in enumerate(self.source_message):
             if "session" not in source_message.context and len(capture.responses):
                 # propagate session updates as a client would do

--- a/test/unittests/test_capture_session.py
+++ b/test/unittests/test_capture_session.py
@@ -217,5 +217,87 @@ class TestCaptureSession(unittest.TestCase):
         self.assertIn("test.partial", types)
 
 
+class TestCaptureSessionNamespaceMirror(unittest.TestCase):
+    """Collapsing the legacy<->ovos.* namespace mirror in the captured stream.
+
+    A bare FakeBus (no MiniCroft handlers) is used so the dual-namespace
+    emit is not perturbed by mock-TTS or other in-process components.
+    """
+
+    def setUp(self):
+        import types
+        from ovos_utils.fakebus import FakeBus
+        LOG.set_level("ERROR")
+        self.bus = FakeBus()
+        self.holder = types.SimpleNamespace(bus=self.bus)
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def _emit_after(self, delay_s, msg):
+        def _run():
+            import time
+            time.sleep(delay_s)
+            self.bus.emit(msg)
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        return t
+
+    def test_namespace_mirror_counted_once(self):
+        """A logical event reaching the bus on BOTH namespaces (a canonical
+        topic and its legacy migration mirror, same payload) is captured once.
+
+        This is the namespace-migration dual-send: without collapsing, a
+        sequence authored against a single namespace would double its counts
+        ("got 10, expected 5").
+        """
+        spec, legacy = "ovos.utterance.speak", "speak"
+        payload = {"utterance": "hello"}
+        cs = CaptureSession(self.holder, eof_msgs=["test.eof"], ignore_messages=[])
+        self._emit_after(0.05, Message(spec, data=dict(payload)))
+        self._emit_after(0.10, Message(legacy, data=dict(payload)))  # mirror
+        self._emit_after(0.15, Message("test.eof"))
+
+        cs.capture(Message("test.trigger"), timeout=3)
+        types_ = [m.msg_type for m in cs.finish()]
+
+        self.assertEqual(types_.count(spec), 1)
+        self.assertEqual(types_.count(legacy), 0,
+                         "the legacy mirror of the preceding canonical message "
+                         "must not be counted a second time")
+
+    def test_namespace_mirror_kept_when_collapse_disabled(self):
+        """collapse_namespace_mirrors=False keeps BOTH namespaces so a test may
+        assert the mirror explicitly."""
+        spec, legacy = "ovos.utterance.speak", "speak"
+        payload = {"utterance": "hello"}
+        cs = CaptureSession(self.holder, eof_msgs=["test.eof"], ignore_messages=[],
+                            collapse_namespace_mirrors=False)
+        self._emit_after(0.05, Message(spec, data=dict(payload)))
+        self._emit_after(0.10, Message(legacy, data=dict(payload)))
+        self._emit_after(0.15, Message("test.eof"))
+
+        cs.capture(Message("test.trigger"), timeout=3)
+        types_ = [m.msg_type for m in cs.finish()]
+
+        self.assertEqual(types_.count(spec), 1)
+        self.assertEqual(types_.count(legacy), 1)
+
+    def test_distinct_events_not_collapsed(self):
+        """Two genuine events on a migrating topic with DIFFERENT payloads are
+        both kept — collapse only drops an adjacent, payload-equal mirror."""
+        cs = CaptureSession(self.holder, eof_msgs=["test.eof"], ignore_messages=[])
+        self._emit_after(0.05, Message("speak", data={"utterance": "first"}))
+        self._emit_after(0.10, Message("speak", data={"utterance": "second"}))
+        self._emit_after(0.15, Message("test.eof"))
+
+        cs.capture(Message("test.trigger"), timeout=3)
+        utts = [m.data.get("utterance") for m in cs.finish()
+                if m.msg_type == "speak"]
+
+        self.assertEqual(utts, ["first", "second"],
+                         "distinct payloads on the same topic must not collapse")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Sequence-based skill e2e tests (`End2EndTest` / `CaptureSession` with hardcoded `expected_messages`) can see **doubled** message counts under the legacy↔`ovos.*` namespace migration — "got 10, expected 5". A single logical event may reach the bus on **both** namespaces (a payload-compatible rename), e.g. `speak` and its counterpart `ovos.utterance.speak`, and the capture firehose counted each once → the sequence written against a single namespace doubles.

## Root cause (evidence)

`FakeBus.emit` fires the `"message"` firehose exactly **once** per `bus.emit`; the namespace mirror is dispatched only to topic-specific listeners, never re-routed through the firehose. So the doubling is **not** the FakeBus bridge hitting the capture firehose. It surfaces when a *producer* emits the same logical event on both namespaces (spec-adoption dual-send), or a bridge that mirrors the firehose — both land two adjacent, payload-equal, migration-counterpart messages in the captured stream.

## Fix

`CaptureSession.handle_message` now drops a captured message that is the transparent namespace mirror of the **immediately-preceding** captured one (migration counterpart topic via `ovos_spec_tools.MIGRATION_MAP`, identical `data`). The stream carries each logical message once.

- Distinct events are untouched — only an adjacent, payload-equal mirror collapses, so genuine N-distinct-message assertions still see N.
- Opt-out via `collapse_namespace_mirrors=False` (plumbed through `End2EndTest`) for tests that assert both namespaces explicitly.
- No-op on the current stack (the firehose is single); it only activates when a real dual-send lands both twins.

## Tests

`test/unittests/test_capture_session.py::TestCaptureSessionNamespaceMirror`:
- `test_namespace_mirror_counted_once` — canonical + legacy mirror of the same payload captured once (red before, green after).
- `test_namespace_mirror_kept_when_collapse_disabled` — opt-out keeps both.
- `test_distinct_events_not_collapsed` — different payloads on the same topic are both kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)