### PR TITLE
fix: restore SessionManager.bus when MiniCroft stops

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -318,6 +318,17 @@ class MiniCroft(SkillManager):
         self._isolated_config = isolate_config
         self._original_xdg_configs: Optional[List[LocalConf]] = None
 
+        # SessionManager.bus is a process-wide class attribute. IntentService
+        # (constructed below via super().__init__()) calls
+        # SessionManager.connect_to_bus(self.bus) in its own __init__,
+        # clobbering it with this instance's FakeBus. If left in place after
+        # stop(), SessionManager.wait_while_speaking()'s `if not cls.bus`
+        # guard sees a stale, truthy, dead bus and blocks/registers listeners
+        # on it instead of whatever bus a later test expects — polluting
+        # every subsequent test in the process. Snapshot it before booting so
+        # stop() can restore it.
+        self._original_sm_bus = SessionManager.bus
+
         if default_pipeline is DEFAULT_PIPELINE_UNSET:
             if is_pipeline_available(DEFAULT_TEST_PIPELINE):
                 self._default_pipeline = DEFAULT_TEST_PIPELINE
@@ -616,6 +627,8 @@ class MiniCroft(SkillManager):
             Configuration.xdg_configs = self._original_xdg_configs
             Configuration.reload()
             LOG.debug("ovoscope: user config restored")
+        SessionManager.bus = self._original_sm_bus
+        LOG.debug("ovoscope: SessionManager.bus restored")
 
 
 def get_minicroft(skill_ids: Union[List[str], str], *args,

--- a/test/unittests/test_minicroft.py
+++ b/test/unittests/test_minicroft.py
@@ -84,6 +84,39 @@ class TestGetMiniCroft(unittest.TestCase):
             mc.stop()
 
 
+class TestMiniCroftSessionManagerBusRestore(unittest.TestCase):
+    """MiniCroft must not leak its FakeBus into the process-wide
+    SessionManager.bus class attribute after stop().
+
+    IntentService.__init__ calls SessionManager.connect_to_bus(self.bus),
+    clobbering SessionManager.bus with MiniCroft's FakeBus. If stop() doesn't
+    restore it, later tests in the same process — e.g. ones using a plain
+    FakeBus and calling SessionManager.wait_while_speaking() — hit the
+    `if not cls.bus` guard with a stale, truthy, dead bus and block/register
+    listeners on the wrong bus.
+    """
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_sessionmanager_bus_restored_after_stop(self):
+        sentinel = object()
+        SessionManager.bus = sentinel
+        try:
+            mc = get_minicroft([])
+            # while running, MiniCroft's own FakeBus has taken over
+            self.assertIs(SessionManager.bus, mc.bus)
+            mc.stop()
+            self.assertIs(SessionManager.bus, sentinel,
+                          "SessionManager.bus must be restored to its "
+                          "pre-boot value after MiniCroft.stop()")
+        finally:
+            SessionManager.bus = None
+
+
 class TestMiniCroftPipelineIsolation(unittest.TestCase):
     """Tests for MiniCroft default_pipeline override."""
 


### PR DESCRIPTION
## Problem

`get_minicroft()` boots a real ovos-core `IntentService`, whose `__init__` calls `SessionManager.connect_to_bus(self.bus)` — mutating the **process-wide class attribute** `SessionManager.bus`. `MiniCroft.stop()` never restored it.

Every consumer repo's test suite inherits cross-test pollution: after an ovoscope e2e suite runs, later tests using a FakeBus hit `SessionManager.wait_while_speaking()`, whose `if not cls.bus` guard sees the stale (truthy, dead) MiniCroft bus, registers `recognizer_loop:audio_output_end` listeners on the wrong bus, and blocks for the full timeout. This is exactly what broke `TestKillableIntents::test_get_response` in ovos-workshop (fixed with per-repo boilerplate in OpenVoiceOS/OVOS-workshop#495 — this PR supersedes the need for that pattern in every downstream repo).

## Fix

`MiniCroft.__init__` snapshots `SessionManager.bus` before booting core; `stop()` restores it as its final step. `connect_to_bus()` only reassigns `cls.bus` (the sessions dict is mutated in place, default_session pipeline/lang already handled by existing code), so this is the only class attribute needing restore.

## Test

`TestMiniCroftSessionManagerBusRestore`: set a sentinel bus, boot, assert `SessionManager.bus is mc.bus` while running, assert the sentinel is back after `stop()`. Suite green (pre-existing `test_listener_stream.py` failures are an unrelated missing optional dep, ovos-dinkum-listener).

Model usage: implemented by a Sonnet subagent orchestrated by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MiniCroft shutdown behavior by restoring the previously configured session bus.
  * Prevented stopped test runs from interfering with listener setup in subsequent runs.

* **Tests**
  * Added coverage verifying that the session bus is correctly restored after MiniCroft stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->