### PR TITLE
fix: Han audit round 1 — teardown safety, session isolation, harness lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## Unreleased
+
+**Fixed — audit round 1 (test isolation, harness lifecycle, verdict accuracy):**
+
+- `End2EndTest.execute()`, `End2EndTest.from_message()` and `OCPTest.execute()`
+  now stop their `MiniCroft` in a `finally` block. A failing assertion no
+  longer leaves the process-wide `SessionManager` and `Configuration` patched.
+- `MiniCroft` snapshots the whole default `Session` at boot and restores it in
+  `stop()`, so `inject_active` and wire-folded session values stay inside the
+  test that caused them.
+- Mock-TTS unduck timers are tracked, made daemon, and cancelled in `stop()`.
+  An orphaned timer can no longer emit onto a closed bus.
+- `BusCoverageTracker` reports the invocation DELTA over its own lifetime.
+  Earlier tests no longer inflate a later test's coverage.
+- `CaptureSession` resets its eof state atomically, records a `timed_out`
+  flag, and returns a copy from `finish()`. A capture timeout now fails with a
+  clear message instead of a message-count mismatch.
+- `ovoscope run` reuses the `MiniCroft` it booted instead of booting a second.
+- `PipelineHarness.match()` no longer treats `mycroft.skill.handler.start`
+  (a SUCCESS signal) as a failure, drops the spinning watcher thread, and gains
+  `match_result()`. `assert_no_match()` now fails on a timeout instead of
+  passing vacuously.
+- `wait_for_match()` accepts `emit=` so the stimulus is sent after
+  subscription, and no longer drops a match that races an intent failure.
+- The OCP HTTP mock attaches its side effect to the patched GET, so configured
+  URLs match. `OCPTest` waits for `ovos.common_play.query.response` instead of
+  sleeping half the timeout.
+- Harness `__exit__` methods close their bus and detach `"message"` capture
+  handlers even when shutdown raises (`AudioServiceHarness`, `MiniPHAL`,
+  `ListenerHarness`, `MiniListener`).
+- `PlaybackServiceHarness` restores the previous `TTS.queue` and refuses a
+  second concurrent harness.
+- Shared `MiniCroft` instances in `intent_cases` are stopped at exit, and at
+  most one stays live. The m2v sync wait removes its listeners and only pays
+  the 3.5s pad when nothing was observed.
+- `MiniSimpleListener.feed_file()` builds a fresh listener when the previous
+  thread refuses to die.
+- PHAL plugin load failures raise by default (`tolerate_load_errors=True` to
+  opt out); tolerated errors are quoted in `assert_emitted` failures.
+- `coverage.py` records manifest parse failures in the report instead of
+  silently understating coverage.
+- `RemoteRecorder.connect()` closes the client on a connect timeout so no
+  reconnect thread is left running.
+
 ## [1.6.1a1](https://github.com/OpenVoiceOS/ovoscope/tree/1.6.1a1) (2026-07-24)
 
 [Full Changelog](https://github.com/OpenVoiceOS/ovoscope/compare/1.6.0a1...1.6.1a1)

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -329,6 +329,27 @@ class MiniCroft(SkillManager):
         # stop() can restore it.
         self._original_sm_bus = SessionManager.bus
 
+        # SessionManager.default_session is a process-wide singleton. Booting a
+        # MiniCroft (and running a test through it) mutates it in several ways:
+        # run() overrides pipeline/lang, End2EndTest.execute() calls
+        # activate_skill() for `inject_active`, and any message that carries a
+        # session with id "default" folds its wire values onto the live object.
+        # Snapshot the whole thing so stop() can put it back exactly as found —
+        # otherwise every later test in the process inherits the mutation.
+        self._default_session_obj = SessionManager.default_session
+        try:
+            self._default_session_state = deepcopy(
+                self._default_session_obj.to_dict())
+        except Exception:  # pragma: no cover - defensive, session_cls may vary
+            self._default_session_state = None
+
+        # Orphaned TTS timers (see _mock_tts below) would fire on a closed bus
+        # after stop() and corrupt the global SessionManager during a LATER
+        # test. Track them so stop() can cancel them.
+        self._tts_timers: List[threading.Timer] = []
+        self._tts_timers_lock = threading.Lock()
+        self._stopped = False
+
         if default_pipeline is DEFAULT_PIPELINE_UNSET:
             if is_pipeline_available(DEFAULT_TEST_PIPELINE):
                 self._default_pipeline = DEFAULT_TEST_PIPELINE
@@ -410,14 +431,30 @@ class MiniCroft(SkillManager):
         # emit audio_output_start synchronously (duck) and schedule a short-delay
         # audio_output_end (unduck) to simulate the full TTS playback lifecycle.
         def _mock_tts(message):
+            if self._stopped:
+                return
             # TTS playback begins — duck immediately.
             # message.forward copies source/destination/session from the speak,
             # matching what the real audio service would do.
             bus.emit(message.forward("recognizer_loop:audio_output_start"))
-            # TTS playback ends after a short delay — unduck
-            threading.Timer(0.1, lambda: bus.emit(
-                message.forward("recognizer_loop:audio_output_end")
-            )).start()
+
+            def _unduck():
+                # stop() may have run while the timer was pending — emitting on
+                # a closed bus here would fold a stale session onto the global
+                # SessionManager and poison the next test.
+                if self._stopped:
+                    return
+                bus.emit(message.forward("recognizer_loop:audio_output_end"))
+
+            # TTS playback ends after a short delay — unduck.
+            # Daemon + tracked so stop() can cancel it and the interpreter can
+            # exit even if one is still pending.
+            timer = threading.Timer(0.1, _unduck)
+            timer.daemon = True
+            with self._tts_timers_lock:
+                self._tts_timers = [t for t in self._tts_timers if t.is_alive()]
+                self._tts_timers.append(timer)
+            timer.start()
 
         bus.on(SpecMessage.SPEAK, _mock_tts)
 
@@ -568,6 +605,22 @@ class MiniCroft(SkillManager):
         self.bus.emit(msg)
 
     def stop(self):
+        self._stopped = True
+        # Cancel any pending mock-TTS unduck timers BEFORE closing the bus, so
+        # none of them can emit onto a dead bus (and fold a stale "default"
+        # session onto the process-wide SessionManager) after teardown.
+        with self._tts_timers_lock:
+            timers, self._tts_timers = self._tts_timers, []
+        for t in timers:
+            try:
+                t.cancel()
+            except Exception:
+                pass
+        for t in timers:
+            try:
+                t.join(timeout=1.0)
+            except Exception:
+                pass
         try:
             super().stop()
         except Exception:
@@ -629,6 +682,43 @@ class MiniCroft(SkillManager):
             LOG.debug("ovoscope: user config restored")
         SessionManager.bus = self._original_sm_bus
         LOG.debug("ovoscope: SessionManager.bus restored")
+        self._restore_default_session()
+
+    def _restore_default_session(self):
+        """Put the process-wide default Session back as it was before boot.
+
+        The explicit pipeline / lang restores above only cover what run()
+        changed. Tests also mutate the default session through
+        ``activate_skill`` (``End2EndTest.inject_active``) and through any
+        message carrying a ``"default"`` session, which folds its wire values
+        onto the singleton. Restoring the full snapshot keeps that mutation
+        inside the test that caused it.
+        """
+        state = getattr(self, "_default_session_state", None)
+        if state is None:
+            return
+        sess = SessionManager.default_session
+        if sess is not getattr(self, "_default_session_obj", None):
+            # The default session object itself was replaced
+            # (SessionManager.reset_default_session) — nothing to restore onto.
+            return
+        # Rebuild a pristine Session from the snapshot and copy every field
+        # onto the live object. Copying only the snapshot keys is not enough:
+        # to_dict() OMITS empty fields, so a skill activated during the test
+        # would have no key to restore and would survive teardown.
+        try:
+            fresh = type(sess).from_dict(deepcopy(state))
+        except Exception:
+            return
+        for key, value in vars(fresh).items():
+            if key.startswith("_"):
+                continue
+            try:
+                setattr(sess, key, value)
+            except Exception:
+                # read-only / computed field — skip it
+                continue
+        LOG.debug("ovoscope: default session state restored")
 
 
 def get_minicroft(skill_ids: Union[List[str], str], *args,
@@ -679,6 +769,9 @@ class CaptureSession:
     done: threading.Event = dataclasses.field(default_factory=lambda: threading.Event())
     _eof_lock: threading.Lock = dataclasses.field(default_factory=lambda: threading.Lock())
     _eof_seen: int = 0
+    # set by capture() when the eof condition was never reached
+    timed_out: bool = False
+    timeout_seconds: Optional[float] = None
 
     def handle_message(self, msg: str):
         if self.done.is_set():
@@ -700,20 +793,38 @@ class CaptureSession:
         for m in self.eof_msgs:
             self.minicroft.bus.on(m, self.handle_end_of_test)
 
-    def capture(self, source_message: Message, timeout=20):
+    def capture(self, source_message: Message, timeout=20) -> bool:
+        """Emit *source_message* and block until an eof message or *timeout*.
+
+        Returns:
+            True if the eof condition was reached, False on timeout. The same
+            value is recorded on :attr:`timed_out` (inverted) so callers that
+            ignore the return value can still tell a timeout from a genuine
+            message-count mismatch.
+        """
         test_message = deepcopy(source_message)  # ensure object not mutated by ovos-core
-        self.done.clear()
+        # Reset the done flag and the eof counter ATOMICALLY: a handler running
+        # between the two would otherwise have its increment thrown away (or set
+        # done for the previous capture's counter).
         with self._eof_lock:
+            self.done.clear()
             self._eof_seen = 0
         self.minicroft.bus.emit(test_message)
-        self.done.wait(timeout)
+        completed = self.done.wait(timeout)
+        if not completed:
+            self.timed_out = True
+            self.timeout_seconds = timeout
+        return completed
 
     def finish(self) -> List[Message]:
         self.done.set()
         self.minicroft.bus.remove("message", self.handle_message)
         for m in self.eof_msgs:
             self.minicroft.bus.remove(m, self.handle_end_of_test)
-        return self.responses
+        # Return a snapshot: the live list is still owned by this session (and
+        # __del__ calls finish() again), so handing it out invites surprise
+        # mutation from a late handler.
+        return list(self.responses)
 
     def __del__(self):
         self.finish()
@@ -824,7 +935,18 @@ class End2EndTest:
         if self.minicroft is None:
             self.minicroft = get_minicroft(self.skill_ids)
             self.managed = True
+        # Teardown MUST run even when an assertion below fails: MiniCroft
+        # patches process-wide globals (SessionManager.bus / default_session,
+        # Configuration) that only stop() restores. Skipping it poisons every
+        # later test in the process.
+        try:
+            return self._execute(timeout)
+        finally:
+            if self.managed and self.minicroft is not None:
+                self.minicroft.stop()
+                self.minicroft = None
 
+    def _execute(self, timeout: int = 30) -> List[Message]:
         if self.test_boot_sequence and self.expected_boot_sequence:
             for expected, received in zip(self.expected_boot_sequence, self.minicroft.boot_messages):
                 assert expected.msg_type == received.msg_type, f"❌ expected boot message_type '{expected.msg_type}' | got '{received.msg_type}'"
@@ -894,6 +1016,15 @@ class End2EndTest:
             all_responses = messages + list(getattr(capture, "async_responses", []))
             _bus_tracker.record_session(all_responses, self.expected_messages)
             self.bus_coverage_report = _bus_tracker.build_report()
+
+        # A capture timeout means the scenario never terminated. Say so plainly
+        # — otherwise it surfaces as a baffling message-count mismatch.
+        assert not capture.timed_out, (
+            f"❌ capture timed out after {capture.timeout_seconds}s waiting for "
+            f"eof_msgs {self.eof_msgs} (needed {self.eof_count}, "
+            f"got {capture._eof_seen}) — captured {len(messages)} messages: "
+            f"{[m.msg_type for m in messages]}"
+        )
 
         if self.test_message_number:
             n1 = len(self.expected_messages)
@@ -1023,11 +1154,6 @@ class End2EndTest:
         if self.print_bus_coverage and self.bus_coverage_report is not None:
             print(self.bus_coverage_report.summary_line())
 
-        if self.managed:
-            self.minicroft.stop()
-            del self.minicroft
-            self.minicroft = None
-
         return messages
 
     @staticmethod
@@ -1115,13 +1241,16 @@ class End2EndTest:
                                  ignore_messages=ignore_messages,
                                  async_messages=async_messages)
 
-        for idx, source_message in enumerate(message):
-            if "session" not in source_message.context and len(capture.responses):
-                # propagate session updates as a client would do
-                source_message.context["session"] = capture.responses[-1].context["session"]
-            capture.capture(source_message, timeout)
-
-        minicroft.stop()
+        # stop() restores process-wide globals — it must run even if a capture
+        # raises.
+        try:
+            for idx, source_message in enumerate(message):
+                if "session" not in source_message.context and len(capture.responses):
+                    # propagate session updates as a client would do
+                    source_message.context["session"] = capture.responses[-1].context["session"]
+                capture.capture(source_message, timeout)
+        finally:
+            minicroft.stop()
         expected_messages = capture.finish()
         return End2EndTest(
             skill_ids=skill_ids,

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -338,9 +338,15 @@ class MiniCroft(SkillManager):
         # otherwise every later test in the process inherits the mutation.
         self._default_session_obj = SessionManager.default_session
         try:
-            self._default_session_state = deepcopy(
-                self._default_session_obj.to_dict())
+            # ovos-bus-client 2.x names these to_dict/from_dict; 1.x uses
+            # serialize/deserialize. Support both — a silent None here would
+            # quietly disable the whole restore.
+            sess_obj = self._default_session_obj
+            dump = getattr(sess_obj, "to_dict", None) or sess_obj.serialize
+            self._default_session_state = deepcopy(dump())
         except Exception:  # pragma: no cover - defensive, session_cls may vary
+            LOG.warning("ovoscope: could not snapshot the default session; "
+                        "state mutated by tests will NOT be restored")
             self._default_session_state = None
 
         # Orphaned TTS timers (see _mock_tts below) would fire on a closed bus
@@ -709,12 +715,18 @@ class MiniCroft(SkillManager):
         # to_dict() OMITS empty fields, so a skill activated during the test
         # would have no key to restore and would survive teardown.
         try:
-            fresh = type(sess).from_dict(deepcopy(state))
+            load = (getattr(type(sess), "from_dict", None) or
+                    type(sess).deserialize)
+            fresh = load(deepcopy(state))
         except Exception:
+            LOG.warning("ovoscope: could not rebuild the default session from "
+                        "its snapshot; leaked state will NOT be restored")
             return
+        # Copy every instance attribute, including underscore-prefixed ones:
+        # some ovos-bus-client versions back public fields (active_skills,
+        # utterance_states, ...) with private storage, and skipping those
+        # would leave the mutation in place.
         for key, value in vars(fresh).items():
-            if key.startswith("_"):
-                continue
             try:
                 setattr(sess, key, value)
             except Exception:

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -697,10 +697,12 @@ class MiniCroft(SkillManager):
         state = getattr(self, "_default_session_state", None)
         if state is None:
             return
+        # Restore onto whatever object is the default session NOW: boot can
+        # replace the singleton (SessionManager.reset_default_session), and
+        # mutations after the swap land on the new object — bailing out on an
+        # identity mismatch would leak exactly the state this exists to scrub.
         sess = SessionManager.default_session
-        if sess is not getattr(self, "_default_session_obj", None):
-            # The default session object itself was replaced
-            # (SessionManager.reset_default_session) — nothing to restore onto.
+        if sess is None:
             return
         # Rebuild a pristine Session from the snapshot and copy every field
         # onto the live object. Copying only the snapshot keys is not enough:

--- a/ovoscope/audio.py
+++ b/ovoscope/audio.py
@@ -310,11 +310,20 @@ class AudioServiceHarness:
         return self
 
     def __exit__(self, *args) -> None:
-        """Shut down AudioService and close the bus."""
-        if self.service:
-            self.service.shutdown()
-        if self.bus:
-            self.bus.close()
+        """Shut down AudioService and close the bus.
+
+        The bus is closed even when ``shutdown()`` raises — leaking an open
+        FakeBus keeps handlers alive and feeds a dead harness.
+        """
+        try:
+            if self.service:
+                self.service.shutdown()
+        finally:
+            if self.bus:
+                try:
+                    self.bus.close()
+                except Exception:
+                    pass
 
     # ------------------------------------------------------------------
     # Control methods
@@ -557,6 +566,9 @@ class PlaybackServiceHarness:
             utterance is captured in :attr:`captured_wavs`.
     """
 
+    # Only one harness may hold the process-wide ``TTS.queue`` at a time.
+    _active: ClassVar[Optional["PlaybackServiceHarness"]] = None
+
     def __init__(self, validate_source: bool = False,
                  disable_ocp: bool = True,
                  tts: Optional[TTS] = None,
@@ -588,6 +600,9 @@ class PlaybackServiceHarness:
         self.mock_tts: Optional[TTS] = None
         # Paths captured from the ``play_audio`` side_effect, in playback order.
         self.captured_wavs: List[str] = []
+        # process-wide TTS.queue bookkeeping (see __enter__)
+        self._previous_tts_queue = None
+        self._replaced_tts_queue: bool = False
         self._play_audio_patcher = None
         self._audio_enabled_patcher = None
         self._audio_output_start = threading.Event()
@@ -603,6 +618,17 @@ class PlaybackServiceHarness:
         from ovos_audio.service import PlaybackService
         from queue import Queue
 
+        # ``TTS.queue`` is process-wide CLASS state, so only ONE
+        # PlaybackServiceHarness may be active at a time — two live harnesses
+        # would fight over the same queue and steal each other's utterances.
+        # Refuse to start rather than corrupt both.
+        if PlaybackServiceHarness._active is not None:
+            raise RuntimeError(
+                "Another PlaybackServiceHarness is already active. "
+                "TTS.queue is process-wide class state, so only one harness "
+                "may run at a time — exit the current one first."
+            )
+
         # Drain any leftover TTS queue from previous tests (class-level state)
         if TTS.queue is not None:
             while not TTS.queue.empty():
@@ -610,7 +636,11 @@ class PlaybackServiceHarness:
                     TTS.queue.get_nowait()
                 except Exception:
                     break
+        # Remember the previous queue object so __exit__ can put it back.
+        self._previous_tts_queue = TTS.queue
+        self._replaced_tts_queue = True
         TTS.queue = Queue()
+        PlaybackServiceHarness._active = self
 
         self.bus = FakeBus(modernize=self.modernize,
                            emit_legacy=self.emit_legacy)
@@ -663,27 +693,39 @@ class PlaybackServiceHarness:
                     pass
             self._play_audio_patcher.stop()
             self.bus.close()
+            self._release_tts_queue()
             raise
 
         return self
 
+    def _release_tts_queue(self) -> None:
+        """Restore the ``TTS.queue`` object this harness replaced."""
+        if getattr(self, "_replaced_tts_queue", False):
+            TTS.queue = self._previous_tts_queue
+            self._replaced_tts_queue = False
+        if PlaybackServiceHarness._active is self:
+            PlaybackServiceHarness._active = None
+
     def __exit__(self, *args) -> None:
-        """Shut down PlaybackService and stop patches."""
-        if self.svc:
-            try:
-                self.svc.shutdown()
-            except Exception:
-                pass
-        if self._play_audio_patcher:
-            try:
-                self._play_audio_patcher.stop()
-            except Exception:
-                pass
-        if self.bus:
-            try:
-                self.bus.close()
-            except Exception:
-                pass
+        """Shut down PlaybackService, stop patches, release the TTS queue."""
+        try:
+            if self.svc:
+                try:
+                    self.svc.shutdown()
+                except Exception:
+                    pass
+            if self._play_audio_patcher:
+                try:
+                    self._play_audio_patcher.stop()
+                except Exception:
+                    pass
+            if self.bus:
+                try:
+                    self.bus.close()
+                except Exception:
+                    pass
+        finally:
+            self._release_tts_queue()
     # ------------------------------------------------------------------
     # Control methods
     # ------------------------------------------------------------------

--- a/ovoscope/bus_coverage.py
+++ b/ovoscope/bus_coverage.py
@@ -388,10 +388,15 @@ class BusCoverageTracker:
         self._global_registrations: Dict[str, int] = {}
         self._global_skill_registrations: Dict[str, Dict[str, int]] = {}
 
+        # The global collector is SESSION-cumulative: it keeps counting across
+        # every test in the process. Snapshot it at tracker START so the report
+        # can use the DELTA (collector_now - snapshot_at_start) — otherwise
+        # every later test inherits the invocation counts of every earlier one.
+        self._collector_baseline: Dict[str, int] = {}
+        self._global_frozen: bool = False
         collector = ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR
         if collector:
-            # Snapshot the global state at initialization
-            self._global_invocations = dict(collector.invocations)
+            self._collector_baseline = dict(collector.invocations)
             self._global_registrations = dict(collector.registrations)
             self._global_skill_registrations = deepcopy(collector.skill_registrations)
 
@@ -401,6 +406,22 @@ class BusCoverageTracker:
         self._asserted: Dict[str, Dict[str, int]] = {}
         self._original_emit: Optional[Any] = None
         self._tracking: bool = False
+
+    def _collector_delta(self) -> Dict[str, int]:
+        """Invocations recorded by the global collector since tracker start.
+
+        Covers this test's own boot sequence when the tracker is constructed
+        before the MiniCroft boots, and excludes everything earlier tests did.
+        """
+        collector = ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR
+        if not collector:
+            return {}
+        delta: Dict[str, int] = {}
+        for msg_type, count in collector.invocations.items():
+            diff = count - self._collector_baseline.get(msg_type, 0)
+            if diff > 0:
+                delta[msg_type] = diff
+        return delta
 
     # ------------------------------------------------------------------
     # Public API
@@ -557,6 +578,13 @@ class BusCoverageTracker:
         """
         if self._tracking:
             return
+        # Freeze the collector delta accumulated between tracker construction
+        # and now — i.e. this test's own boot sequence when the tracker was
+        # created before the MiniCroft booted. Everything from here on is
+        # counted locally by the patched emit below, so freezing here is what
+        # keeps the two sources from double counting the same emit.
+        self._global_invocations = self._collector_delta()
+        self._global_frozen = True
         original_emit = self._bus.emit
         invocations = self._invocations
 
@@ -630,6 +658,11 @@ class BusCoverageTracker:
         Returns:
             Fully populated :class:`BusCoverageReport` instance.
         """
+        if not self._global_frozen:
+            # start_tracking() was never called — fall back to the full delta
+            # over the tracker's lifetime.
+            self._global_invocations = self._collector_delta()
+            self._global_frozen = True
         all_skill_ids = (
             set(self._registered)
             | set(self._observed)

--- a/ovoscope/cli.py
+++ b/ovoscope/cli.py
@@ -184,6 +184,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         _die("MiniCroft did not reach READY state in time.")
 
     try:
+        # Hand the already-booted MiniCroft to the test. Without this,
+        # execute() boots a SECOND managed MiniCroft and both patch the same
+        # process-wide globals. `managed = False` keeps ownership here — the
+        # finally block below stops it.
+        test.minicroft = mc
+        test.managed = False
         test.execute(timeout=timeout)
         print("[run] PASS")
         return 0

--- a/ovoscope/coverage.py
+++ b/ovoscope/coverage.py
@@ -35,7 +35,9 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+from ovos_utils.log import LOG
 
 
 # Entry-point groups that indicate the repo type.
@@ -93,6 +95,9 @@ class EcosystemCoverageReport:
 
     repos: List[RepoCoverage] = field(default_factory=list)
     scan_root: str = ""
+    # (path, reason) for every manifest that could not be parsed. A malformed
+    # pyproject.toml used to be swallowed, which silently understated coverage.
+    parse_errors: List[Tuple[str, str]] = field(default_factory=list)
 
     @property
     def coverage_pct(self) -> float:
@@ -212,7 +217,8 @@ def _find_setup_pys(root: str) -> List[str]:
     return sorted(results)
 
 
-def _parse_setup_py_entry_points(setup_py_path: str) -> Dict[str, List[str]]:
+def _parse_setup_py_entry_points(setup_py_path: str,
+                                 errors: Optional[List[Tuple[str, str]]] = None) -> Dict[str, List[str]]:
     """Extract entry-point groups from a ``setup.py`` file via regex.
 
     Detects lines like::
@@ -239,7 +245,8 @@ def _parse_setup_py_entry_points(setup_py_path: str) -> Dict[str, List[str]]:
     try:
         with open(setup_py_path, "r", encoding="utf-8") as fh:
             source = fh.read()
-    except Exception:
+    except (OSError, UnicodeDecodeError) as exc:
+        _record_error(errors, setup_py_path, f"unreadable: {exc}")
         return eps
 
     # --- Pass 1: collect literal string assignments for ENTRY_POINT variables ---
@@ -290,7 +297,8 @@ def _parse_setup_py_entry_points(setup_py_path: str) -> Dict[str, List[str]]:
     return eps
 
 
-def _parse_entry_points(pyproject_path: str) -> Dict[str, List[str]]:
+def _parse_entry_points(pyproject_path: str,
+                        errors: Optional[List[Tuple[str, str]]] = None) -> Dict[str, List[str]]:
     """Parse entry-point groups from a ``pyproject.toml`` file.
 
     Uses stdlib ``tomllib`` (Python 3.11+) or falls back to line-by-line
@@ -302,18 +310,28 @@ def _parse_entry_points(pyproject_path: str) -> Dict[str, List[str]]:
     Returns:
         Mapping of entry-point group name → list of entry-point IDs.
     """
+    eps: Dict[str, List[str]] = {}
     try:
         import tomllib  # Python 3.11+
-        with open(pyproject_path, "rb") as fh:
-            data = tomllib.load(fh)
-        eps: Dict[str, List[str]] = {}
-        # setuptools style
-        for group, entries in data.get("project", {}).get("entry-points", {}).items():
-            eps[group] = list(entries.keys())
-        # Also check [project.scripts] for CLI tools
-        return eps
-    except (ImportError, Exception):
-        pass
+    except ImportError:
+        tomllib = None  # type: ignore[assignment]
+
+    if tomllib is not None:
+        try:
+            with open(pyproject_path, "rb") as fh:
+                data = tomllib.load(fh)
+            # setuptools style
+            for group, entries in data.get("project", {}).get(
+                    "entry-points", {}).items():
+                eps[group] = list(entries.keys())
+            return eps
+        except tomllib.TOMLDecodeError as exc:
+            # A malformed manifest is a real problem — record it instead of
+            # silently reporting the repo as having no entry points.
+            _record_error(errors, pyproject_path, f"invalid TOML: {exc}")
+        except OSError as exc:
+            _record_error(errors, pyproject_path, f"unreadable: {exc}")
+            return eps
 
     # Fallback: simple line-by-line scan for entry-point group headers
     eps = {}
@@ -331,9 +349,17 @@ def _parse_entry_points(pyproject_path: str) -> Dict[str, List[str]]:
                         eps[current_group].append(key)
                 elif line.startswith("["):
                     current_group = None
-    except Exception:
-        pass
+    except (OSError, IndexError, UnicodeDecodeError) as exc:
+        _record_error(errors, pyproject_path, f"fallback scan failed: {exc}")
     return eps
+
+
+def _record_error(errors: Optional[List[Tuple[str, str]]],
+                  path: str, reason: str) -> None:
+    """Append a parse failure to *errors* and log it."""
+    LOG.warning("ovoscope coverage: %s — %s", path, reason)
+    if errors is not None:
+        errors.append((path, reason))
 
 
 def _has_e2e_tests(repo_root: str) -> bool:
@@ -442,7 +468,8 @@ def scan_workspace(root: str) -> EcosystemCoverageReport:
     # --- pyproject.toml repos ---
     for pyproject_path in _find_pyproject_tomls(root):
         repo_root = os.path.dirname(pyproject_path)
-        entry_point_groups = _parse_entry_points(pyproject_path)
+        entry_point_groups = _parse_entry_points(pyproject_path,
+                                                 report.parse_errors)
         cov = _collect_repo(repo_root, entry_point_groups)
         if cov is not None:
             report.repos.append(cov)
@@ -453,7 +480,8 @@ def scan_workspace(root: str) -> EcosystemCoverageReport:
         repo_root = os.path.dirname(setup_py_path)
         if repo_root in seen_roots:
             continue
-        entry_point_groups = _parse_setup_py_entry_points(setup_py_path)
+        entry_point_groups = _parse_setup_py_entry_points(setup_py_path,
+                                                         report.parse_errors)
         cov = _collect_repo(repo_root, entry_point_groups)
         if cov is not None:
             report.repos.append(cov)

--- a/ovoscope/coverage.py
+++ b/ovoscope/coverage.py
@@ -314,7 +314,10 @@ def _parse_entry_points(pyproject_path: str,
     try:
         import tomllib  # Python 3.11+
     except ImportError:
-        tomllib = None  # type: ignore[assignment]
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            tomllib = None  # type: ignore[assignment]
 
     if tomllib is not None:
         try:

--- a/ovoscope/e2e.py
+++ b/ovoscope/e2e.py
@@ -73,20 +73,33 @@ def wait_for_match(
     expected_types: List[str],
     *,
     timeout: float = 5.0,
+    emit: Optional[Message] = None,
 ) -> Optional[Message]:
     """Subscribe to ``expected_types`` and ``complete_intent_failure``; return
     the first match Message, or ``None`` on failure / timeout.
 
-    The caller is responsible for emitting the utterance *after* calling this
-    helper if used in a pytest style — for the ``unittest`` style use
-    :meth:`E2EPipelineHarness.send_and_capture` which emits internally.
+    This helper BLOCKS, so a single-threaded caller cannot emit the utterance
+    after calling it. Pass the message as *emit* instead: it is emitted after
+    the handlers are subscribed, so no reply can be missed. Emit it yourself
+    beforehand only when the reply is guaranteed to be asynchronous.
+
+    Args:
+        bus: The bus to subscribe on.
+        expected_types: Message types that count as a match.
+        timeout: Seconds to wait for a verdict.
+        emit: Message emitted once the handlers are in place.
+
+    Returns:
+        The first matching :class:`Message`, or ``None``.
     """
     got: List[Message] = []
+    lock = threading.Lock()
     done = threading.Event()
     failed = threading.Event()
 
     def _on_match(msg: Message) -> None:
-        got.append(msg)
+        with lock:
+            got.append(msg)
         done.set()
 
     def _on_fail(_msg: Message) -> None:
@@ -97,14 +110,31 @@ def wait_for_match(
         bus.on(t, _on_match)
     bus.on("complete_intent_failure", _on_fail)
     try:
+        if emit is not None:
+            bus.emit(emit)
         done.wait(timeout=timeout)
     finally:
         for t in expected_types:
             bus.remove(t, _on_match)
         bus.remove("complete_intent_failure", _on_fail)
-    if failed.is_set() and not got:
+    return _first_match(got, failed, lock)
+
+
+def _first_match(got: List[Message], failed: threading.Event,
+                 lock: threading.Lock) -> Optional[Message]:
+    """Return the first captured match, tolerating a match/fail race.
+
+    ``failed`` can be observed set while a concurrent ``got.append`` is still
+    in flight, which used to drop a real match. Take the lock (the appender
+    holds it) and re-read once before giving up.
+    """
+    with lock:
+        if got:
+            return got[0]
+    if failed.is_set():
         return None
-    return got[0] if got else None
+    with lock:
+        return got[0] if got else None
 
 
 def wait_for_failure(bus, *, timeout: float = 2.0) -> bool:
@@ -301,31 +331,12 @@ class E2EPipelineHarness(unittest.TestCase):
         session: Optional[Session] = None,
     ) -> Optional[Message]:
         """Emit ``utterance`` and return the first match Message (or None)."""
-        got: List[Message] = []
-        done = threading.Event()
-        failed = threading.Event()
-
-        def _on_match(msg: Message) -> None:
-            got.append(msg)
-            done.set()
-
-        def _on_fail(_msg: Message) -> None:
-            failed.set()
-            done.set()
-
-        for t in expected_types:
-            self.bus.on(t, _on_match)
-        self.bus.on("complete_intent_failure", _on_fail)
-        try:
-            self.bus.emit(self.make_utterance(utterance, session=session))
-            done.wait(timeout=timeout)
-        finally:
-            for t in expected_types:
-                self.bus.remove(t, _on_match)
-            self.bus.remove("complete_intent_failure", _on_fail)
-        if failed.is_set() and not got:
-            return None
-        return got[0] if got else None
+        return wait_for_match(
+            self.bus,
+            expected_types,
+            timeout=timeout,
+            emit=self.make_utterance(utterance, session=session),
+        )
 
     def expect_no_match(
         self,

--- a/ovoscope/intent_cases.py
+++ b/ovoscope/intent_cases.py
@@ -50,6 +50,7 @@ you only want a subset, or to test against custom pipeline stages.
 """
 from __future__ import annotations
 
+import atexit
 import dataclasses
 import time
 from copy import deepcopy
@@ -282,9 +283,11 @@ def _wait_for_m2v_sync(mc, max_wait: float = 15.0,
         seen["count"] += 1
         seen["last_t"] = time.monotonic()
 
-    mc.bus.ee.on("padatious:register_intent",
-                 lambda _: on_register(None))
-    mc.bus.ee.on("register_intent", lambda _: on_register(None))
+    def on_padatious(_):
+        on_register(None)
+
+    def on_adapt(_):
+        on_register(None)
 
     # Wildcard "message" listener catches the serialized form on FakeBus.
     def on_any(serialized):
@@ -297,20 +300,56 @@ def _wait_for_m2v_sync(mc, max_wait: float = 15.0,
         if t == "padatious:register_intent" or t == "register_intent":
             on_register(None)
 
+    mc.bus.ee.on("padatious:register_intent", on_padatious)
+    mc.bus.ee.on("register_intent", on_adapt)
     mc.bus.ee.on("message", on_any)
 
     t0 = time.monotonic()
-    mc.bus.emit(Message("mycroft.ready", {}, {}))
+    try:
+        mc.bus.emit(Message("mycroft.ready", {}, {}))
 
-    # Wait for the burst of register events to settle.
-    while time.monotonic() - t0 < max_wait:
-        time.sleep(0.1)
-        if seen["count"] > 0 and (time.monotonic() - seen["last_t"]) > quiet_window:
-            break
-    # m2v's handle_sync_intents does an internal time.sleep(3) before the
-    # actual intent set update. Pad for that ceiling.
-    time.sleep(3.5)
-    return time.monotonic() - t0
+        # Wait for the burst of register events to settle.
+        while time.monotonic() - t0 < max_wait:
+            time.sleep(0.1)
+            if seen["count"] > 0 and (time.monotonic() - seen["last_t"]) > quiet_window:
+                break
+        if seen["count"] > 0:
+            # Register events arrived AND went quiet — the sync is observably
+            # finished, so there is nothing left to wait for.
+            return time.monotonic() - t0
+        # Nothing was observed. We cannot tell whether m2v is mid-sync, so pad
+        # for the ceiling of its internal time.sleep(3) in handle_sync_intents.
+        time.sleep(3.5)
+        return time.monotonic() - t0
+    finally:
+        # Always detach: these listeners live on the shared MiniCroft bus and
+        # would keep counting for the rest of the process.
+        for topic, handler in (("padatious:register_intent", on_padatious),
+                               ("register_intent", on_adapt),
+                               ("message", on_any)):
+            try:
+                mc.bus.ee.remove_listener(topic, handler)
+            except Exception:
+                pass
+
+
+def stop_shared_minicrofts() -> None:
+    """Stop every cached shared MiniCroft and empty the cache.
+
+    Registered with :mod:`atexit`; also safe to call from a session-scoped
+    fixture. A MiniCroft that is never stopped keeps its patches on the
+    process-wide ``SessionManager`` and ``Configuration``.
+    """
+    cache = globals().get(_SHARED_MINICROFT_KEY) or {}
+    for mc in list(cache.values()):
+        try:
+            mc.stop()
+        except Exception:
+            pass
+    cache.clear()
+
+
+atexit.register(stop_shared_minicrofts)
 
 
 def _shared_minicroft(skill_id: str, langs: List[str], m2v_warmup: float):
@@ -319,10 +358,22 @@ def _shared_minicroft(skill_id: str, langs: List[str], m2v_warmup: float):
     Caches the instance on a process-global so every generated class
     shares the same boot. ``m2v_warmup`` is now an *upper bound*: if the
     deterministic event-based wait finishes faster, we return early.
+
+    At most ONE instance stays alive: MiniCroft patches process-wide globals,
+    so a second live instance would clobber the first. Requesting a different
+    key stops the cached instance before booting the new one.
     """
     cache = globals().setdefault(_SHARED_MINICROFT_KEY, {})
     key = (skill_id, tuple(langs))
     if key not in cache:
+        # Keep at most one live MiniCroft — two of them fight over the same
+        # SessionManager / Configuration globals.
+        for stale_key in [k for k in cache if k != key]:
+            stale = cache.pop(stale_key)
+            try:
+                stale.stop()
+            except Exception:
+                pass
         LOG.set_level("CRITICAL")
         secondary = [l for l in langs if l != "en-US"]
         mc = get_minicroft([skill_id], secondary_langs=secondary or None)

--- a/ovoscope/listener.py
+++ b/ovoscope/listener.py
@@ -333,6 +333,9 @@ class MiniListener:
                     return
             self._messages.append(msg)
 
+        # Kept on the instance so shutdown() can unsubscribe it — a capture
+        # handler left on a shared bus keeps feeding a dead harness.
+        self._capture = _capture
         self.bus.on("message", _capture)
 
         try:
@@ -675,14 +678,27 @@ class MiniListener:
     # ------------------------------------------------------------------
 
     def shutdown(self) -> None:
-        """Shut down all loaded transformer and wake-word plugins gracefully."""
-        if self.transformers is not None:
-            self.transformers.shutdown()
-        for engine in self._ww.values():
-            try:
-                engine.shutdown()
-            except Exception:
-                pass
+        """Shut down all loaded transformer and wake-word plugins gracefully.
+
+        Also detaches the wildcard ``"message"`` capture handler so a shared
+        bus stops feeding this harness after it is gone.
+        """
+        try:
+            if self.transformers is not None:
+                self.transformers.shutdown()
+            for engine in self._ww.values():
+                try:
+                    engine.shutdown()
+                except Exception:
+                    pass
+        finally:
+            capture = getattr(self, "_capture", None)
+            if capture is not None:
+                try:
+                    self.bus.remove("message", capture)
+                except Exception:
+                    pass
+                self._capture = None
 
 
 # ---------------------------------------------------------------------------

--- a/ovoscope/ocp.py
+++ b/ovoscope/ocp.py
@@ -38,6 +38,8 @@ Example::
 """
 from __future__ import annotations
 
+import json
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -110,25 +112,43 @@ class OCPTest:
         from ovoscope import get_minicroft  # avoid circular at module level
 
         captured: List[Message] = []
+        got_response = threading.Event()
 
         mc = get_minicroft(self.skill_ids, lang=self.lang, max_wait=60,
                            modernize=self.modernize,
                            emit_legacy=self.emit_legacy)
-        mc.bus.on("message", lambda m: captured.append(
-            Message.deserialize(m) if isinstance(m, str) else m
-        ))
+
+        def _capture(m: Any) -> None:
+            captured.append(Message.deserialize(m) if isinstance(m, str) else m)
+
+        def _on_query_response(_m: Any) -> None:
+            got_response.set()
+
+        mc.bus.on("message", _capture)
+        mc.bus.on("ovos.common_play.query.response", _on_query_response)
 
         src_msg = Message(
             "recognizer_loop:utterance",
             data={"utterances": [self.utterance], "lang": self.lang},
         )
 
-        patches = self._build_patches()
-        with _apply_patches(patches):
-            mc.bus.emit(src_msg)
-            time.sleep(self.timeout * 0.5)  # wait for async OCP responses
-
-        mc.stop()
+        # MiniCroft.stop() restores process-wide globals — it must run even if
+        # emit or a patch raises.
+        try:
+            patches = self._build_patches()
+            with _apply_patches(patches):
+                mc.bus.emit(src_msg)
+                # Wait for the OCP skills to answer instead of sleeping a fixed
+                # fraction of the timeout: fast skills no longer pay the full
+                # wait, slow ones are no longer cut off early.
+                if got_response.wait(self.timeout):
+                    # Several OCP skills answer the same query; give the
+                    # stragglers a short grace period after the first reply.
+                    time.sleep(min(0.5, self.timeout * 0.1))
+        finally:
+            mc.bus.remove("ovos.common_play.query.response", _on_query_response)
+            mc.bus.remove("message", _capture)
+            mc.stop()
 
         assert_ocp_query_response(
             captured,
@@ -147,12 +167,57 @@ class OCPTest:
         if not self.mock_responses:
             return patches
 
-        mock_response = _build_mock_response(self.mock_responses)
-
         targets = list(self.patch_targets) + ["requests.Session.get", "requests.get"]
         for target in targets:
-            patches.append(patch(target, return_value=mock_response))
+            # The side effect must live on the patched GET — that is what
+            # receives the URL. Attaching it to the response mock could never
+            # see a URL, so no configured body ever matched and json() always
+            # returned {}.
+            patches.append(patch(target,
+                                 side_effect=_build_get_side_effect(
+                                     self.mock_responses)))
         return patches
+
+
+def _build_get_side_effect(mock_responses: Dict[str, Any]):
+    """Build a side effect for a patched ``requests`` GET.
+
+    The returned callable receives the request URL (the first positional
+    argument of ``requests.get`` / ``requests.Session.get``) and answers with a
+    response mock whose ``json()`` returns the body configured for the first
+    *mock_responses* key found in that URL.
+
+    Args:
+        mock_responses: URL-substring → response body mapping.
+
+    Returns:
+        A callable suitable for ``patch(..., side_effect=...)``.
+    """
+
+    def _get(*args: Any, **kwargs: Any) -> MagicMock:
+        url = ""
+        for candidate in args:
+            if isinstance(candidate, str):
+                url = candidate
+                break
+        else:
+            url = str(kwargs.get("url", ""))
+
+        body: Any = {}
+        for key, value in mock_responses.items():
+            if key in url:
+                body = value
+                break
+
+        response = MagicMock()
+        response.url = url
+        response.json.return_value = body
+        response.text = json.dumps(body) if isinstance(body, (dict, list)) else str(body)
+        response.status_code = 200
+        response.ok = True
+        return response
+
+    return _get
 
 
 def _build_mock_response(mock_responses: Dict[str, Any]) -> MagicMock:

--- a/ovoscope/phal.py
+++ b/ovoscope/phal.py
@@ -66,6 +66,9 @@ class MiniPHAL:
         emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec topic
             is emitted (spec producer -> legacy listener). Set both False to
             exercise a single namespace with no bridging.
+        tolerate_load_errors: When False (default), a plugin that fails to load
+            raises immediately. When True, the failure is warned about, kept in
+            :attr:`load_errors`, and quoted in ``assert_emitted`` failures.
 
     Example::
 
@@ -96,6 +99,7 @@ class MiniPHAL:
         config: Optional[Dict[str, Dict[str, Any]]] = None,
         modernize: bool = True,
         emit_legacy: bool = True,
+        tolerate_load_errors: bool = False,
     ) -> None:
         self.plugin_ids: List[str] = plugin_ids or []
         self.plugin_instances: Dict[str, Any] = plugin_instances or {}
@@ -104,8 +108,11 @@ class MiniPHAL:
         self.modernize: bool = modernize
         self.emit_legacy: bool = emit_legacy
         self._bus: FakeBus = FakeBus(modernize=modernize, emit_legacy=emit_legacy)
+        self.tolerate_load_errors: bool = tolerate_load_errors
         self._captured: List[Message] = []
         self._loaded: Dict[str, Any] = {}
+        # (plugin_id, error text) for every plugin that failed to load
+        self.load_errors: List[tuple] = []
 
     # ------------------------------------------------------------------
     # Context manager interface
@@ -118,13 +125,22 @@ class MiniPHAL:
         return self
 
     def __exit__(self, *_: Any) -> None:
-        """Shut down all loaded plugins and close the bus."""
-        for plugin in self._loaded.values():
+        """Shut down all loaded plugins, detach the capture handler, close the bus."""
+        try:
+            for plugin in self._loaded.values():
+                try:
+                    plugin.shutdown()
+                except Exception:
+                    pass
+        finally:
             try:
-                plugin.shutdown()
+                self._bus.remove("message", self._capture)
             except Exception:
                 pass
-        self._bus.remove("message", self._capture)
+            try:
+                self._bus.close()
+            except Exception:
+                pass
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -140,17 +156,25 @@ class MiniPHAL:
         self._captured.append(message)
 
     def _load_plugins(self) -> None:
-        """Load PHAL plugins via factories, pre-built instances, or OPM."""
+        """Load PHAL plugins via factories, pre-built instances, or OPM.
+
+        A load failure RAISES by default. Degrading it to a warning only moves
+        the failure: the plugin is silently absent and resurfaces much later as
+        an unrelated ``assert_emitted`` timeout. Set
+        ``tolerate_load_errors=True`` to keep the old behaviour; the errors are
+        then recorded in :attr:`load_errors` and quoted in assertion failures.
+
+        Raises:
+            RuntimeError: If any plugin fails to load and
+                ``tolerate_load_errors`` is False.
+        """
         for plugin_id in self.plugin_ids:
             if plugin_id in self.plugin_factories:
                 try:
                     instance = self.plugin_factories[plugin_id](self._bus)
                 except Exception as exc:
-                    import warnings
-                    warnings.warn(
-                        f"Factory for PHAL plugin {plugin_id!r} raised: {exc}",
-                        stacklevel=2,
-                    )
+                    self._record_load_error(
+                        plugin_id, f"factory raised: {exc}")
                     instance = None
             elif plugin_id in self.plugin_instances:
                 instance = self.plugin_instances[plugin_id]
@@ -158,6 +182,20 @@ class MiniPHAL:
                 instance = self._instantiate_plugin(plugin_id)
             if instance is not None:
                 self._loaded[plugin_id] = instance
+
+    def _record_load_error(self, plugin_id: str, reason: str) -> None:
+        """Record — or raise on — a plugin load failure."""
+        self.load_errors.append((plugin_id, reason))
+        if not self.tolerate_load_errors:
+            raise RuntimeError(
+                f"PHAL plugin {plugin_id!r} failed to load: {reason}. "
+                f"Pass tolerate_load_errors=True to continue without it."
+            )
+        import warnings
+        warnings.warn(
+            f"PHAL plugin {plugin_id!r} failed to load: {reason}",
+            stacklevel=3,
+        )
 
     def _instantiate_plugin(self, plugin_id: str) -> Optional[Any]:
         """Instantiate a PHAL plugin by its OPM entry-point ID.
@@ -174,11 +212,7 @@ class MiniPHAL:
             plugin = PHALPlugin(bus=self._bus, config=cfg, plugin_id=plugin_id)
             return plugin
         except Exception as exc:
-            import warnings
-            warnings.warn(
-                f"Failed to load PHAL plugin {plugin_id!r}: {exc}",
-                stacklevel=2,
-            )
+            self._record_load_error(plugin_id, str(exc))
             return None
 
     # ------------------------------------------------------------------
@@ -218,9 +252,17 @@ class MiniPHAL:
                     return msg
             time.sleep(0.05)
         captured_types = [m.msg_type for m in self._captured]
+        hint = ""
+        if self.load_errors:
+            # A tolerated load failure is the usual cause of this timeout —
+            # name it instead of leaving the caller to guess.
+            hint = (
+                f" NOTE: {len(self.load_errors)} PHAL plugin(s) failed to load "
+                f"and were tolerated: {self.load_errors}"
+            )
         raise AssertionError(
             f"Expected message type {msg_type!r} was not emitted within {timeout}s. "
-            f"Captured: {captured_types}"
+            f"Captured: {captured_types}.{hint}"
         )
 
     def assert_not_emitted(self, msg_type: str, wait: float = 0.2) -> None:
@@ -264,6 +306,9 @@ class PHALTest:
         modernize: Forwarded to :class:`MiniPHAL` — FakeBus bridges legacy->spec.
         emit_legacy: Forwarded to :class:`MiniPHAL` — FakeBus bridges spec->legacy.
             Set both False to exercise a single namespace with no bridging.
+        tolerate_load_errors: Forwarded to :class:`MiniPHAL`. False (default)
+            makes a plugin load failure raise instead of surfacing later as an
+            unrelated ``assert_emitted`` timeout.
 
     Example::
 
@@ -288,6 +333,7 @@ class PHALTest:
     timeout: float = 5.0
     modernize: bool = True
     emit_legacy: bool = True
+    tolerate_load_errors: bool = False
 
     def execute(self) -> List[Message]:
         """Run the test: load plugins, emit trigger, assert expectations.
@@ -305,6 +351,7 @@ class PHALTest:
             config=self.config,
             modernize=self.modernize,
             emit_legacy=self.emit_legacy,
+            tolerate_load_errors=self.tolerate_load_errors,
         ) as phal:
             phal.emit(self.trigger_message, wait=0.1)
 

--- a/ovoscope/pipeline.py
+++ b/ovoscope/pipeline.py
@@ -34,6 +34,33 @@ from typing import Any, Dict, List, Optional
 from ovos_utils.messagebus import Message
 
 
+@dataclass
+class MatchResult:
+    """Discriminated outcome of a single :meth:`PipelineHarness.match_result`.
+
+    Attributes:
+        outcome: One of ``"matched"``, ``"no_match"`` or ``"timeout"``.
+            ``"no_match"`` means the pipeline explicitly reported an intent
+            failure. ``"timeout"`` means nothing came back at all — the
+            pipeline gave no verdict, which is a harness problem and must not
+            be read as "no match".
+        message: The matched :class:`Message`, or ``None``.
+    """
+
+    outcome: str
+    message: Optional[Message] = None
+
+    @property
+    def matched(self) -> bool:
+        """True only when the pipeline produced a match."""
+        return self.outcome == "matched"
+
+    @property
+    def timed_out(self) -> bool:
+        """True when the pipeline gave no verdict within the timeout."""
+        return self.outcome == "timeout"
+
+
 class _SinkSkill:
     """Internal catch-all fallback skill so matched intents have somewhere to route.
 
@@ -168,6 +195,81 @@ class PipelineHarness:
     # Public API
     # ------------------------------------------------------------------
 
+    def match_result(self, utterance: str, timeout: float = 5.0) -> "MatchResult":
+        """Send *utterance* through the pipeline and report what happened.
+
+        Unlike :meth:`match`, this distinguishes the three outcomes a caller
+        must tell apart: a match, an explicit intent failure, and a timeout
+        (nothing at all came back — usually a broken harness, not a genuine
+        "no match").
+
+        Args:
+            utterance: Text utterance to send.
+            timeout: Seconds to wait for a verdict (default 5.0).
+
+        Returns:
+            A :class:`MatchResult`.
+        """
+        if self._mc is None:
+            raise RuntimeError("PipelineHarness must be used as a context manager.")
+
+        import threading
+
+        captured: List[Message] = []
+        lock = threading.Lock()
+        done = threading.Event()
+        _failed = threading.Event()
+
+        success_type = "intent.service.skills.activated"
+        # NOTE: `mycroft.skill.handler.start` is NOT a failure — it fires on a
+        # SUCCESSFUL match, right before the skill handler runs. Treating it as
+        # one made every successful match report "no match".
+        failure_types = ["intent_failure", "complete_intent_failure"]
+
+        def _on_success(msg: Any) -> None:
+            if isinstance(msg, str):
+                try:
+                    msg = Message.deserialize(msg)
+                except Exception:
+                    return
+            with lock:
+                captured.append(msg)
+            done.set()
+
+        def _on_failure(msg: Any) -> None:
+            _failed.set()
+            done.set()
+
+        self._mc.bus.on(success_type, _on_success)
+        for et in failure_types:
+            self._mc.bus.on(et, _on_failure)
+
+        try:
+            src = Message(
+                "recognizer_loop:utterance",
+                data={"utterances": [utterance], "lang": self.lang},
+            )
+            self._mc.bus.emit(src)
+            # Wait directly on the shared event — no watcher thread. The old
+            # watcher polled at 20Hz forever after a timeout, because the
+            # handlers were already removed so its events could never be set.
+            completed = done.wait(timeout=timeout)
+        finally:
+            self._mc.bus.remove(success_type, _on_success)
+            for et in failure_types:
+                self._mc.bus.remove(et, _on_failure)
+
+        with lock:
+            got = captured[0] if captured else None
+        if got is not None:
+            # A real match wins over a concurrent failure signal.
+            return MatchResult(outcome="matched", message=got)
+        if _failed.is_set():
+            return MatchResult(outcome="no_match", message=None)
+        if not completed:
+            return MatchResult(outcome="timeout", message=None)
+        return MatchResult(outcome="no_match", message=None)
+
     def match(self, utterance: str, timeout: float = 5.0) -> Optional[Message]:
         """Send *utterance* through the pipeline and return the matched message.
 
@@ -179,64 +281,7 @@ class PipelineHarness:
             The ``recognizer_loop:utterance`` response message if a match occurs,
             otherwise ``None``.
         """
-        if self._mc is None:
-            raise RuntimeError("PipelineHarness must be used as a context manager.")
-
-        import threading
-
-        captured: List[Message] = []
-        _matched = threading.Event()
-        _failed = threading.Event()
-
-        success_type = "intent.service.skills.activated"
-        failure_types = ["intent_failure", "mycroft.skill.handler.start"]
-
-        def _on_success(msg: Any) -> None:
-            if isinstance(msg, str):
-                try:
-                    msg = Message.deserialize(msg)
-                except Exception:
-                    return
-            captured.append(msg)
-            _matched.set()
-
-        def _on_failure(msg: Any) -> None:
-            _failed.set()
-
-        self._mc.bus.on(success_type, _on_success)
-        for et in failure_types:
-            self._mc.bus.on(et, _on_failure)
-
-        src = Message(
-            "recognizer_loop:utterance",
-            data={"utterances": [utterance], "lang": self.lang},
-        )
-        self._mc.bus.emit(src)
-
-        # Wait for either a match or a failure signal
-        import threading as _threading
-        done = _threading.Event()
-
-        def _wait_either() -> None:
-            while not _matched.is_set() and not _failed.is_set():
-                _matched.wait(timeout=0.05)
-                if _matched.is_set() or _failed.is_set():
-                    break
-            done.set()
-
-        watcher = _threading.Thread(target=_wait_either, daemon=True)
-        watcher.start()
-        timed_out = not done.wait(timeout=timeout)
-
-        self._mc.bus.remove(success_type, _on_success)
-        for et in failure_types:
-            self._mc.bus.remove(et, _on_failure)
-
-        if timed_out:
-            return None
-        if _failed.is_set():
-            return None
-        return captured[0] if captured else None
+        return self.match_result(utterance, timeout=timeout).message
 
     def assert_matches(
         self,
@@ -258,7 +303,12 @@ class PipelineHarness:
         Raises:
             AssertionError: If no match is found or the intent type is wrong.
         """
-        msg = self.match(utterance, timeout=timeout)
+        result = self.match_result(utterance, timeout=timeout)
+        assert result.outcome != "timeout", (
+            f"Pipeline gave no verdict for utterance {utterance!r} within "
+            f"{timeout}s — neither a match nor an intent failure was emitted."
+        )
+        msg = result.message
         assert msg is not None, (
             f"Expected utterance {utterance!r} to be matched by the pipeline, but no match occurred."
         )
@@ -276,9 +326,19 @@ class PipelineHarness:
             timeout: Seconds to observe before asserting absence (default 2.0).
 
         Raises:
-            AssertionError: If a match is unexpectedly found.
+            AssertionError: If a match is unexpectedly found, or if the
+                pipeline gave no verdict at all within *timeout* (silence is
+                a broken harness, not proof of absence).
         """
-        msg = self.match(utterance, timeout=timeout)
+        result = self.match_result(utterance, timeout=timeout)
+        if result.outcome == "timeout":
+            raise AssertionError(
+                f"Pipeline gave no verdict for utterance {utterance!r} within "
+                f"{timeout}s — no match AND no intent failure was emitted. "
+                f"Absence of a match cannot be asserted from silence; check "
+                f"that the harness is wired and the pipeline is loaded."
+            )
+        msg = result.message
         if msg is not None and msg.msg_type != "intent_failure":
             raise AssertionError(
                 f"Utterance {utterance!r} was unexpectedly matched: {msg.msg_type!r}"

--- a/ovoscope/remote_recorder.py
+++ b/ovoscope/remote_recorder.py
@@ -100,6 +100,13 @@ class RemoteRecorder:
         deadline = time.monotonic() + 10.0
         while not self._client.connected_event.is_set():
             if time.monotonic() > deadline:
+                # Close the client before giving up — MessageBusClient keeps a
+                # reconnect thread alive forever otherwise.
+                client, self._client = self._client, None
+                try:
+                    client.close()
+                except Exception:
+                    pass
                 raise ConnectionError(f"Could not connect to {self.bus_url} within 10 seconds.")
             time.sleep(0.1)
 

--- a/ovoscope/simple_listener.py
+++ b/ovoscope/simple_listener.py
@@ -38,6 +38,7 @@ from typing import Any, List, Optional, Union
 
 from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
+from ovos_utils.log import LOG
 
 from ovoscope.voice_loop import (
     ListenerHarness,
@@ -144,7 +145,10 @@ class MiniSimpleListener(ListenerHarness):
             wakeword = MockHotWordEngine("hey_mycroft", trigger_after=2)
 
         self.callbacks = _SimpleBusCallbacks(self.bus)
-        self.listener = SimpleListener(
+        self._listener_cls = SimpleListener
+        # Kept so a wedged listener thread can be replaced with a fresh object
+        # instead of being reused (see feed_file).
+        self._listener_kwargs = dict(
             wakeword=wakeword,
             mic=None,  # supplied per-run by feed_file
             vad=vad_instance if vad_instance is not None else MockVADEngine(),
@@ -154,6 +158,11 @@ class MiniSimpleListener(ListenerHarness):
             max_speech_seconds=max_speech_seconds,
             callbacks=self.callbacks,
         )
+        self.listener = self._listener_cls(**self._listener_kwargs)
+
+    def _new_listener(self) -> Any:
+        """Build a fresh listener object from the original constructor args."""
+        return self._listener_cls(**self._listener_kwargs)
 
     def feed_file(
         self,
@@ -193,6 +202,16 @@ class MiniSimpleListener(ListenerHarness):
         finally:
             self.listener.stop()
             self.listener.join(timeout=2.0)
+            if self.listener.is_alive():
+                # The thread refused to die. Reusing it would let it keep
+                # appending to `_messages` during the NEXT run. Abandon it
+                # (it is a daemon of the test process) and start clean.
+                LOG.warning(
+                    "MiniSimpleListener: listener thread still alive 2s after "
+                    "stop(); abandoning it and building a fresh listener for "
+                    "the next run to avoid cross-run message pollution."
+                )
+                self.listener = self._new_listener()
 
         self._last_messages = list(self._messages)
         return list(self._messages)

--- a/ovoscope/voice_loop.py
+++ b/ovoscope/voice_loop.py
@@ -677,7 +677,26 @@ class ListenerHarness:
         return self
 
     def __exit__(self, *_: Any) -> None:
-        self.shutdown()
+        try:
+            self.shutdown()
+        finally:
+            self.detach_capture()
+
+    def detach_capture(self) -> None:
+        """Unsubscribe the wildcard ``"message"`` capture handler.
+
+        The bus may be shared with another harness or with the caller. A
+        capture handler left behind keeps appending to a dead harness's
+        message list — and every later message shows up in ``_messages``.
+        """
+        bus = getattr(self, "bus", None)
+        capture = getattr(self, "_capture", None)
+        if bus is None or capture is None:
+            return
+        try:
+            bus.remove("message", capture)
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     # dependency. >=8 is required: the pytest_pycollect_makemodule hook dropped the
     # 'path' argument in pytest 8.
     "pytest>=8",
+    # coverage.py validates pyproject.toml manifests; stdlib tomllib only
+    # exists on 3.11+, so 3.10 needs the backport for the same honesty.
+    "tomli>=2; python_version<'3.11'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/test/unittests/test_audit_round1.py
+++ b/test/unittests/test_audit_round1.py
@@ -1,0 +1,722 @@
+"""Adversarial regression tests for the Han audit round 1 fixes.
+
+Each test here reproduces a defect that leaked state, hung, or reported a
+false verdict. They are written to FAIL against the pre-fix code.
+"""
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import SessionManager
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.log import LOG
+
+import ovoscope
+from ovoscope import CaptureSession, End2EndTest, get_minicroft
+from ovoscope.bus_coverage import BusCoverageTracker
+from ovoscope.pipeline import MatchResult
+
+
+# ---------------------------------------------------------------------------
+# A. teardown must run even when an assertion fails
+# ---------------------------------------------------------------------------
+
+@pytest.mark.timeout(600)  # boots a real MiniCroft (slow shutdown)
+class TestTeardownOnFailure(unittest.TestCase):
+    """execute() must stop a managed MiniCroft on the failure path too."""
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_managed_minicroft_stopped_when_assertion_fails(self):
+        original_bus = SessionManager.bus
+        original_pipeline = SessionManager.default_session.pipeline[:]
+
+        test = End2EndTest(
+            skill_ids=[],
+            source_message=Message("ovoscope.audit.never.answered"),
+            # deliberately wrong: forces the message-count assertion to fail
+            expected_messages=[Message("ovoscope.audit.does.not.happen")],
+            eof_msgs=["ovoscope.audit.eof.never.emitted"],
+            verbose=False,
+        )
+        with self.assertRaises(AssertionError):
+            test.execute(timeout=2)
+
+        # The whole point: globals are back even though execute() raised.
+        self.assertIs(SessionManager.bus, original_bus)
+        self.assertEqual(SessionManager.default_session.pipeline, original_pipeline)
+        self.assertIsNone(test.minicroft)
+
+    def test_capture_timeout_is_reported_as_a_timeout(self):
+        """A timeout must say so, not masquerade as a count mismatch."""
+        test = End2EndTest(
+            skill_ids=[],
+            source_message=Message("ovoscope.audit.never.answered"),
+            expected_messages=[],
+            eof_msgs=["ovoscope.audit.eof.never.emitted"],
+            test_message_number=False,
+            verbose=False,
+        )
+        with self.assertRaises(AssertionError) as ctx:
+            test.execute(timeout=2)
+        self.assertIn("capture timed out", str(ctx.exception))
+        self.assertIn("ovoscope.audit.eof.never.emitted", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# B. the process-wide default session must survive a test unchanged
+# ---------------------------------------------------------------------------
+
+@pytest.mark.timeout(600)  # boots a real MiniCroft (slow shutdown)
+class TestDefaultSessionIsolation(unittest.TestCase):
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_inject_active_does_not_leak_into_default_session(self):
+        before = {s[0] for s in SessionManager.default_session.active_skills}
+
+        test = End2EndTest(
+            skill_ids=[],
+            source_message=Message("ovoscope.audit.never.answered"),
+            expected_messages=[],
+            eof_msgs=["ovoscope.audit.eof.never.emitted"],
+            inject_active=["ovoscope-audit-ghost.test"],
+            test_message_number=False,
+            verbose=False,
+        )
+        with self.assertRaises(AssertionError):
+            test.execute(timeout=2)
+
+        after = {s[0] for s in SessionManager.default_session.active_skills}
+        self.assertEqual(before, after,
+                         "inject_active leaked into the default session")
+
+    def test_stop_restores_default_session_lang_and_pipeline(self):
+        sess = SessionManager.default_session
+        original_lang = sess.lang
+        original_pipeline = sess.pipeline[:]
+
+        mc = get_minicroft([], lang="pt-PT")
+        try:
+            self.assertEqual(SessionManager.default_session.lang, "pt-PT")
+        finally:
+            mc.stop()
+
+        self.assertEqual(SessionManager.default_session.lang, original_lang)
+        self.assertEqual(SessionManager.default_session.pipeline, original_pipeline)
+
+    def test_default_session_mutated_mid_test_is_restored(self):
+        """Even a mutation MiniCroft never made itself must be undone."""
+        mc = get_minicroft([])
+        try:
+            SessionManager.default_session.activate_skill("ovoscope-audit-x.test")
+        finally:
+            mc.stop()
+        actives = {s[0] for s in SessionManager.default_session.active_skills}
+        self.assertNotIn("ovoscope-audit-x.test", actives)
+
+
+# ---------------------------------------------------------------------------
+# C. mock-TTS timers must not outlive the MiniCroft
+# ---------------------------------------------------------------------------
+
+@pytest.mark.timeout(600)  # boots a real MiniCroft (slow shutdown)
+class TestTTSTimerLifecycle(unittest.TestCase):
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_timers_tracked_cancelled_and_silent_after_stop(self):
+        # One boot covers the whole lifecycle: MiniCroft boots retain several
+        # hundred MB each even after stop(), so the two assertions share it.
+        mc = get_minicroft([])
+        late = []
+        mc.bus.on("recognizer_loop:audio_output_end", lambda m: late.append(m))
+        mc.bus.emit(Message("speak", {"utterance": "hello"}))
+        with mc._tts_timers_lock:
+            timers = list(mc._tts_timers)
+        self.assertTrue(timers, "no TTS timer was tracked")
+        self.assertTrue(all(t.daemon for t in timers),
+                        "TTS timers must be daemon threads")
+        late.clear()  # drop anything emitted before stop() — only post-stop
+        mc.stop()
+
+        # stop() must have cancelled/joined every one of them.
+        with mc._tts_timers_lock:
+            self.assertEqual(mc._tts_timers, [])
+        self.assertFalse(any(t.is_alive() for t in timers))
+        time.sleep(0.4)  # well past the 0.1s timer
+        self.assertEqual(late, [],
+                         "an orphaned TTS timer fired after stop()")
+
+
+# ---------------------------------------------------------------------------
+# D. bus-coverage must not inherit earlier tests' invocation counts
+# ---------------------------------------------------------------------------
+
+class TestBusCoverageDelta:
+
+    def setup_method(self, _):
+        self._prev_flag = ovoscope.GLOBAL_BUS_COVERAGE
+        self._prev_collector = ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR
+
+    def teardown_method(self, _):
+        ovoscope.GLOBAL_BUS_COVERAGE = self._prev_flag
+        ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR = self._prev_collector
+
+    def _tracker(self):
+        bus = FakeBus()
+        minicroft = MagicMock()
+        minicroft.plugin_skills = {}
+        return bus, BusCoverageTracker(bus, minicroft)
+
+    def test_earlier_tests_invocations_are_excluded(self):
+        """Counts from BEFORE the tracker existed must not inflate the report."""
+        ovoscope.GLOBAL_BUS_COVERAGE = True
+        ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR = ovoscope.GlobalBusCoverageCollector()
+        collector = ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR
+        # pretend 5 earlier tests each fired this event
+        for _ in range(5):
+            collector.record_invocation("shared.event")
+
+        bus, tracker = self._tracker()
+        tracker.start_tracking()
+        bus.emit(Message("shared.event"))  # 1x during THIS test
+        tracker.stop_tracking()
+        tracker._registered = {"__core__": {"shared.event": 1}}
+
+        report = tracker.build_report()
+        skill = next(s for s in report.skills if s.skill_id == "__core__")
+        handler = next(h for h in skill.listeners if h.msg_type == "shared.event")
+        assert handler.invocation_count == 1, (
+            "coverage inherited invocations from earlier tests"
+        )
+
+    def test_own_boot_is_counted_when_tracker_precedes_boot(self):
+        ovoscope.GLOBAL_BUS_COVERAGE = True
+        ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR = ovoscope.GlobalBusCoverageCollector()
+        collector = ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR
+        collector.record_invocation("boot.event")  # an EARLIER test
+
+        bus, tracker = self._tracker()
+        collector.record_invocation("boot.event")  # THIS test's boot
+        tracker.start_tracking()
+        tracker.stop_tracking()
+        tracker._registered = {"__core__": {"boot.event": 1}}
+
+        report = tracker.build_report()
+        skill = next(s for s in report.skills if s.skill_id == "__core__")
+        handler = next(h for h in skill.listeners if h.msg_type == "boot.event")
+        assert handler.invocation_count == 1
+
+    def test_tracking_window_is_not_double_counted(self):
+        ovoscope.GLOBAL_BUS_COVERAGE = True
+        ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR = ovoscope.GlobalBusCoverageCollector()
+
+        bus, tracker = self._tracker()
+        tracker.start_tracking()
+        for _ in range(3):
+            bus.emit(Message("dup.event"))
+        tracker.stop_tracking()
+        tracker._registered = {"__core__": {"dup.event": 1}}
+
+        report = tracker.build_report()
+        skill = next(s for s in report.skills if s.skill_id == "__core__")
+        handler = next(h for h in skill.listeners if h.msg_type == "dup.event")
+        assert handler.invocation_count == 3
+
+
+# ---------------------------------------------------------------------------
+# E. CaptureSession races
+# ---------------------------------------------------------------------------
+
+class TestCaptureSessionRaces(unittest.TestCase):
+    """CaptureSession only ever touches ``minicroft.bus`` — a FakeBus-backed
+    stub keeps these race tests fast and saves a full (memory-hungry) boot."""
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+        from types import SimpleNamespace
+        from ovos_utils.fakebus import FakeBus
+        self.mc = SimpleNamespace(bus=FakeBus())
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_capture_reports_timeout(self):
+        cap = CaptureSession(self.mc, eof_msgs=["ovoscope.audit.no.such.eof"])
+        completed = cap.capture(Message("ovoscope.audit.ping"), timeout=1)
+        cap.finish()
+        self.assertFalse(completed)
+        self.assertTrue(cap.timed_out)
+        self.assertEqual(cap.timeout_seconds, 1)
+
+    def test_finish_returns_a_copy(self):
+        cap = CaptureSession(self.mc, eof_msgs=["ovoscope.audit.eof"])
+        cap.capture(Message("ovoscope.audit.eof"), timeout=5)
+        got = cap.finish()
+        self.assertIsNot(got, cap.responses,
+                         "finish() handed out the live response list")
+        got.append(Message("mutated.by.caller"))
+        self.assertNotIn("mutated.by.caller",
+                         [m.msg_type for m in cap.responses])
+
+    def test_eof_counter_reset_is_atomic(self):
+        """A late eof handler must never leak into the NEXT capture."""
+        cap = CaptureSession(self.mc, eof_msgs=["ovoscope.audit.eof"],
+                             eof_count=2)
+        # one eof is not enough — capture must time out
+        completed = cap.capture(Message("ovoscope.audit.eof"), timeout=1)
+        self.assertFalse(completed)
+        self.assertEqual(cap._eof_seen, 1)
+        # a second capture starts from a clean counter
+        completed = cap.capture(Message("ovoscope.audit.eof"), timeout=1)
+        cap.finish()
+        self.assertFalse(completed,
+                         "eof counter was not reset between captures")
+
+
+# ---------------------------------------------------------------------------
+# G. PipelineHarness.match() verdicts
+# ---------------------------------------------------------------------------
+
+class TestMatchResult:
+
+    def test_handler_start_does_not_suppress_a_match(self):
+        """`mycroft.skill.handler.start` fires on SUCCESS, never on failure.
+
+        Treating it as a failure signal made every successful match report
+        "no match".
+        """
+        from ovoscope.pipeline import PipelineHarness
+
+        bus = FakeBus()
+        matched = Message("intent.service.skills.activated",
+                          {"skill_id": "audit.skill"})
+
+        def _answer(_m):
+            # exactly what a successful dispatch looks like on the wire
+            bus.emit(Message("mycroft.skill.handler.start"))
+            bus.emit(matched)
+
+        bus.on("recognizer_loop:utterance", _answer)
+
+        harness = PipelineHarness.__new__(PipelineHarness)
+        harness._mc = MagicMock()
+        harness._mc.bus = bus
+        harness.lang = "en-US"
+
+        result = harness.match_result("turn on the lights", timeout=3.0)
+        assert result.outcome == "matched", result.outcome
+        assert result.message.msg_type == "intent.service.skills.activated"
+
+    def test_match_result_discriminates_outcomes(self):
+        assert MatchResult("matched", Message("x")).matched is True
+        assert MatchResult("timeout").timed_out is True
+        assert MatchResult("no_match").matched is False
+        assert MatchResult("no_match").timed_out is False
+
+    def test_assert_no_match_fails_on_timeout(self):
+        """Silence is a broken harness, not proof of absence."""
+        from ovoscope.pipeline import PipelineHarness
+
+        harness = PipelineHarness.__new__(PipelineHarness)
+        harness.match_result = lambda utt, timeout=2.0: MatchResult("timeout")
+        with pytest.raises(AssertionError, match="no verdict"):
+            PipelineHarness.assert_no_match(harness, "nonsense")
+
+    def test_assert_no_match_passes_on_explicit_failure(self):
+        from ovoscope.pipeline import PipelineHarness
+
+        harness = PipelineHarness.__new__(PipelineHarness)
+        harness.match_result = lambda utt, timeout=2.0: MatchResult("no_match")
+        PipelineHarness.assert_no_match(harness, "nonsense")
+
+    def test_assert_matches_fails_loudly_on_timeout(self):
+        from ovoscope.pipeline import PipelineHarness
+
+        harness = PipelineHarness.__new__(PipelineHarness)
+        harness.match_result = lambda utt, timeout=5.0: MatchResult("timeout")
+        with pytest.raises(AssertionError, match="no verdict"):
+            PipelineHarness.assert_matches(harness, "turn on the lights")
+
+    def test_match_returns_the_message_of_a_match_result(self):
+        from ovoscope.pipeline import PipelineHarness
+
+        msg = Message("intent.service.skills.activated")
+        harness = PipelineHarness.__new__(PipelineHarness)
+        harness.match_result = lambda utt, timeout=5.0: MatchResult("matched", msg)
+        assert PipelineHarness.match(harness, "hi") is msg
+
+
+# ---------------------------------------------------------------------------
+# H. wait_for_match emit= parameter and match/fail race
+# ---------------------------------------------------------------------------
+
+class TestWaitForMatch:
+
+    def test_emit_happens_after_subscription(self):
+        """A synchronous FakeBus reply must not be missed."""
+        from ovoscope.e2e import wait_for_match
+
+        bus = FakeBus()
+        # answers synchronously, inside emit()
+        bus.on("audit.q", lambda m: bus.emit(Message("audit.a")))
+
+        got = wait_for_match(bus, ["audit.a"], timeout=2.0,
+                             emit=Message("audit.q"))
+        assert got is not None
+        assert got.msg_type == "audit.a"
+
+    def test_match_wins_over_concurrent_failure(self):
+        """A real match must not be dropped because a failure raced it."""
+        from ovoscope.e2e import wait_for_match
+
+        bus = FakeBus()
+
+        def _answer(_m):
+            bus.emit(Message("complete_intent_failure"))
+            bus.emit(Message("audit.match"))
+
+        bus.on("audit.q2", _answer)
+        got = wait_for_match(bus, ["audit.match"], timeout=2.0,
+                             emit=Message("audit.q2"))
+        assert got is not None and got.msg_type == "audit.match"
+
+    def test_docstring_no_longer_tells_callers_to_emit_after(self):
+        from ovoscope.e2e import wait_for_match
+
+        assert "emit" in (wait_for_match.__doc__ or "")
+        assert "BLOCKS" in (wait_for_match.__doc__ or "")
+
+
+# ---------------------------------------------------------------------------
+# I. OCP HTTP mock must see the URL
+# ---------------------------------------------------------------------------
+
+class TestOCPHttpMock:
+
+    def test_configured_url_body_is_returned(self):
+        from ovoscope.ocp import _build_get_side_effect
+
+        get = _build_get_side_effect({"bandcamp.com": {"tracks": ["Blue Note"]}})
+        resp = get("https://bandcamp.com/api/search?q=jazz")
+        assert resp.json() == {"tracks": ["Blue Note"]}
+
+    def test_unconfigured_url_falls_back_to_empty(self):
+        from ovoscope.ocp import _build_get_side_effect
+
+        get = _build_get_side_effect({"bandcamp.com": {"tracks": []}})
+        assert get("https://example.com/other").json() == {}
+
+    def test_url_passed_as_keyword_is_matched(self):
+        from ovoscope.ocp import _build_get_side_effect
+
+        get = _build_get_side_effect({"youtube.com": {"items": [1]}})
+        assert get(url="https://youtube.com/results").json() == {"items": [1]}
+
+    def test_patch_targets_receive_the_side_effect(self):
+        from ovoscope.ocp import OCPTest
+
+        test = OCPTest(skill_ids=[], utterance="play jazz",
+                       mock_responses={"bandcamp.com": {"ok": True}})
+        patches = test._build_patches()
+        assert patches, "no patches were built"
+        import requests
+        for p in patches:
+            p.__enter__()
+        try:
+            assert requests.get("https://bandcamp.com/x").json() == {"ok": True}
+        finally:
+            for p in reversed(patches):
+                p.__exit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# J / K. harness teardown robustness
+# ---------------------------------------------------------------------------
+
+class TestHarnessTeardown:
+
+    def test_audio_harness_closes_bus_when_shutdown_raises(self):
+        from ovoscope.audio import AudioServiceHarness
+
+        harness = AudioServiceHarness.__new__(AudioServiceHarness)
+        harness.service = MagicMock()
+        harness.service.shutdown.side_effect = RuntimeError("boom")
+        harness.bus = MagicMock()
+
+        with pytest.raises(RuntimeError):
+            harness.__exit__(None, None, None)
+        harness.bus.close.assert_called_once()
+
+    def test_two_playback_harnesses_are_refused(self):
+        from ovoscope.audio import PlaybackServiceHarness
+
+        first = PlaybackServiceHarness.__new__(PlaybackServiceHarness)
+        PlaybackServiceHarness._active = first
+        try:
+            with pytest.raises(RuntimeError, match="already active"):
+                with PlaybackServiceHarness():
+                    pass
+        finally:
+            PlaybackServiceHarness._active = None
+
+    def test_playback_harness_restores_previous_tts_queue(self):
+        from queue import Queue
+        from ovos_plugin_manager.templates.tts import TTS
+        from ovoscope.audio import PlaybackServiceHarness
+
+        sentinel = Queue()
+        TTS.queue = sentinel
+        try:
+            with PlaybackServiceHarness():
+                assert TTS.queue is not sentinel
+            assert TTS.queue is sentinel, "previous TTS.queue was not restored"
+            assert PlaybackServiceHarness._active is None
+        finally:
+            TTS.queue = sentinel
+
+    def test_miniphal_detaches_capture_handler(self):
+        from ovoscope.phal import MiniPHAL
+
+        phal = MiniPHAL()
+        bus = phal._bus
+        with phal:
+            pass
+        before = len(phal._captured)
+        bus.emit(Message("audit.after.exit"))
+        assert len(phal._captured) == before, (
+            "MiniPHAL kept capturing after __exit__"
+        )
+
+    def test_listener_harness_detaches_capture_handler(self):
+        from ovoscope.voice_loop import ListenerHarness
+
+        bus = FakeBus()
+        harness = ListenerHarness(bus=bus)
+        with harness:
+            bus.emit(Message("audit.during"))
+        assert any(m.msg_type == "audit.during" for m in harness._messages)
+        before = len(harness._messages)
+        bus.emit(Message("audit.after"))
+        assert len(harness._messages) == before, (
+            "capture handler survived __exit__ on a shared bus"
+        )
+
+
+# ---------------------------------------------------------------------------
+# N. PHAL load failures
+# ---------------------------------------------------------------------------
+
+class TestPHALLoadErrors:
+
+    def test_load_failure_raises_by_default(self):
+        from ovoscope.phal import MiniPHAL
+
+        def _boom(_bus):
+            raise ValueError("no hardware")
+
+        with pytest.raises(RuntimeError, match="failed to load"):
+            with MiniPHAL(plugin_ids=["audit.plugin"],
+                          plugin_factories={"audit.plugin": _boom}):
+                pass
+
+    def test_tolerated_failure_is_recorded_and_quoted(self):
+        from ovoscope.phal import MiniPHAL
+
+        def _boom(_bus):
+            raise ValueError("no hardware")
+
+        with MiniPHAL(plugin_ids=["audit.plugin"],
+                      plugin_factories={"audit.plugin": _boom},
+                      tolerate_load_errors=True) as phal:
+            assert phal.load_errors
+            with pytest.raises(AssertionError) as ctx:
+                phal.assert_emitted("audit.never", timeout=0.1)
+            assert "failed to load" in str(ctx.value)
+
+
+# ---------------------------------------------------------------------------
+# O. coverage.py must not swallow a malformed manifest
+# ---------------------------------------------------------------------------
+
+class TestCoverageParseErrors:
+
+    def test_malformed_pyproject_is_recorded(self, tmp_path):
+        from ovoscope.coverage import _parse_entry_points
+
+        bad = tmp_path / "pyproject.toml"
+        bad.write_text('[project\nname = "oops"\n')
+        errors = []
+        _parse_entry_points(str(bad), errors)
+        assert errors, "a malformed pyproject.toml was silently ignored"
+        assert "invalid TOML" in errors[0][1]
+
+    def test_unreadable_setup_py_is_recorded(self, tmp_path):
+        from ovoscope.coverage import _parse_setup_py_entry_points
+
+        errors = []
+        _parse_setup_py_entry_points(str(tmp_path / "missing_setup.py"), errors)
+        assert errors and "unreadable" in errors[0][1]
+
+    def test_report_exposes_parse_errors(self):
+        from ovoscope.coverage import EcosystemCoverageReport
+
+        assert EcosystemCoverageReport().parse_errors == []
+
+    def test_valid_pyproject_records_no_error(self, tmp_path):
+        from ovoscope.coverage import _parse_entry_points
+
+        good = tmp_path / "pyproject.toml"
+        good.write_text(
+            '[project]\nname = "x"\n\n'
+            '[project.entry-points."opm.skill"]\n'
+            '"my-skill.author" = "my_skill:create"\n'
+        )
+        errors = []
+        eps = _parse_entry_points(str(good), errors)
+        assert errors == []
+        assert eps["opm.skill"] == ["my-skill.author"]
+
+
+# ---------------------------------------------------------------------------
+# P. RemoteRecorder must not leak a reconnecting client
+# ---------------------------------------------------------------------------
+
+class TestRemoteRecorderConnectLeak:
+
+    def test_client_is_closed_on_connect_timeout(self):
+        from ovoscope.remote_recorder import RemoteRecorder
+
+        rec = RemoteRecorder(bus_url="ws://127.0.0.1:1/core")
+        fake_client = MagicMock()
+        fake_client.connected_event.is_set.return_value = False
+
+        with patch("ovos_bus_client.client.MessageBusClient",
+                   return_value=fake_client), \
+                patch("time.monotonic", side_effect=[0.0, 100.0, 200.0]), \
+                patch("time.sleep"):
+            with pytest.raises(ConnectionError):
+                rec.connect()
+
+        fake_client.close.assert_called_once()
+        assert rec._client is None, "a dead client was left reconnecting forever"
+
+
+# ---------------------------------------------------------------------------
+# F. cmd_run must not boot a second MiniCroft
+# ---------------------------------------------------------------------------
+
+class TestCliRunSingleMiniCroft:
+
+    def test_cmd_run_hands_its_minicroft_to_the_test(self, tmp_path):
+        import argparse
+        from ovoscope import cli
+
+        fixture = tmp_path / "f.json"
+        fixture.write_text("{}")
+
+        mc = MagicMock()
+        test = MagicMock()
+        test.skill_ids = []
+
+        with patch("ovoscope.End2EndTest.from_path", return_value=test), \
+                patch("ovoscope.get_minicroft", return_value=mc):
+            cli.cmd_run(argparse.Namespace(fixture=str(fixture), timeout=5,
+                                           verbose=False))
+
+        assert test.minicroft is mc, "cmd_run did not reuse its MiniCroft"
+        assert test.managed is False, "execute() would boot a second MiniCroft"
+        mc.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# L. shared MiniCroft lifecycle
+# ---------------------------------------------------------------------------
+
+class TestSharedMiniCroftLifecycle:
+
+    def test_only_one_instance_stays_live(self):
+        from ovoscope import intent_cases
+
+        key = intent_cases._SHARED_MINICROFT_KEY
+        cache = vars(intent_cases).setdefault(key, {})
+        cache.clear()
+
+        old = MagicMock()
+        cache[("old-skill", ("en-US",))] = old
+
+        new = MagicMock()
+        with patch.object(intent_cases, "get_minicroft", return_value=new):
+            got = intent_cases._shared_minicroft("new-skill", ["en-US"], 0)
+
+        assert got is new
+        old.stop.assert_called_once()
+        assert len(cache) == 1, "two shared MiniCrofts were kept alive"
+        cache.clear()
+
+    def test_stop_shared_minicrofts_empties_the_cache(self):
+        from ovoscope import intent_cases
+
+        key = intent_cases._SHARED_MINICROFT_KEY
+        cache = vars(intent_cases).setdefault(key, {})
+        cache.clear()
+        mc = MagicMock()
+        cache[("s", ("en-US",))] = mc
+
+        intent_cases.stop_shared_minicrofts()
+        mc.stop.assert_called_once()
+        assert cache == {}
+
+
+# ---------------------------------------------------------------------------
+# M. MiniSimpleListener must not reuse a wedged listener thread
+# ---------------------------------------------------------------------------
+
+class TestSimpleListenerWedgedThread:
+
+    def test_wedged_listener_is_replaced(self):
+        pytest.importorskip("ovos_simple_listener")
+        from ovoscope.simple_listener import MiniSimpleListener
+
+        # SimpleListener eagerly builds a real microphone in __init__, so the
+        # harness can only be constructed where a microphone plugin exists.
+        # Construct the harness itself under the guard: earlier tests can
+        # change the loaded Configuration, so probing the factory separately
+        # is order-dependent — the harness construction is the real gate.
+        try:
+            harness = MiniSimpleListener()
+        except Exception as e:
+            pytest.skip(f"no usable microphone plugin: {e}")
+        first = harness.listener
+        try:
+            # pretend the thread refuses to die
+            with patch.object(type(first), "is_alive", return_value=True), \
+                    patch.object(type(first), "start"), \
+                    patch.object(type(first), "stop"), \
+                    patch.object(type(first), "join"):
+                harness.feed_file(b"\x00" * 4096, timeout=0.2)
+            assert harness.listener is not first, (
+                "a wedged listener was reused for the next run"
+            )
+        finally:
+            harness.detach_capture()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_global_bus_coverage.py
+++ b/test/unittests/test_global_bus_coverage.py
@@ -60,19 +60,26 @@ class TestGlobalBusCoverage:
         assert ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR.invocations["global.emit"] == 1
 
     def test_tracker_snapshots_global_state(self):
-        """BusCoverageTracker should snapshot global state at __init__."""
+        """BusCoverageTracker snapshots the collector as a BASELINE at __init__.
+
+        Invocations that happened before the tracker existed belong to earlier
+        tests and must be subtracted, not inherited.
+        """
         ovoscope.GLOBAL_BUS_COVERAGE = True
         ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR = ovoscope.GlobalBusCoverageCollector()
         ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR.record_invocation("boot.event")
         ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR.record_registration("boot.handler")
-        
+
         bus = FakeBus()
         minicroft = MagicMock()
         minicroft.plugin_skills = {}
-        
+
         tracker = BusCoverageTracker(bus, minicroft)
-        
-        assert tracker._global_invocations["boot.event"] == 1
+
+        # baseline holds the earlier count …
+        assert tracker._collector_baseline["boot.event"] == 1
+        # … and the delta over that baseline is zero.
+        assert tracker._collector_delta() == {}
         assert tracker._global_registrations["boot.handler"] == 1
 
     def test_tracker_merges_global_registrations(self):
@@ -92,27 +99,28 @@ class TestGlobalBusCoverage:
         assert "boot.unclaimed" in tracker._registered["__core__"]
 
     def test_tracker_merges_global_invocations(self):
-        """build_report should sum global and local invocations."""
+        """build_report sums THIS test's boot delta and its local invocations."""
         ovoscope.GLOBAL_BUS_COVERAGE = True
         ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR = ovoscope.GlobalBusCoverageCollector()
-        ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR.record_invocation("shared.event") # 1x during boot
-        
+
         bus = FakeBus()
         minicroft = MagicMock()
         minicroft.plugin_skills = {}
-        
+
         tracker = BusCoverageTracker(bus, minicroft)
+        # boot happens AFTER the tracker exists, so it belongs to this test
+        ovoscope.GLOBAL_BUS_COVERAGE_COLLECTOR.record_invocation("shared.event")
         tracker.start_tracking()
-        bus.emit(Message("shared.event")) # 1x during test
+        bus.emit(Message("shared.event"))  # 1x during test
         tracker.stop_tracking()
-        
+
         # Manually register the listener so it shows up in report
         tracker._registered = {"__core__": {"shared.event": 1}}
-        
+
         report = tracker.build_report()
         skill = next(s for s in report.skills if s.skill_id == "__core__")
         handler = next(h for h in skill.listeners if h.msg_type == "shared.event")
-        
-        # 1 (boot) + 1 (test) = 2
+
+        # 1 (this test's boot) + 1 (test) = 2
         assert handler.invocation_count == 2
         assert handler.covered is True

--- a/test/unittests/test_phal.py
+++ b/test/unittests/test_phal.py
@@ -207,8 +207,24 @@ class TestPluginFactories:
             # stale_instance was NOT loaded
             assert phal._loaded["dual-plugin"] is not stale_instance
 
-    def test_factory_raising_warns_and_skips_plugin(self):
-        """A factory that raises issues a warning and the plugin is not loaded."""
+    def test_factory_raising_fails_the_harness(self):
+        """A factory that raises stops the harness instead of degrading.
+
+        A silently skipped plugin used to resurface much later as an
+        unrelated assert_emitted timeout.
+        """
+        def bad_factory(bus: FakeBus):
+            raise RuntimeError("factory error")
+
+        with pytest.raises(RuntimeError, match="bad-plugin"):
+            with MiniPHAL(
+                plugin_ids=["bad-plugin"],
+                plugin_factories={"bad-plugin": bad_factory},
+            ):
+                pass
+
+    def test_factory_raising_warns_and_skips_plugin_when_tolerated(self):
+        """With tolerate_load_errors, the failure warns and the plugin is skipped."""
         import warnings
 
         def bad_factory(bus: FakeBus):
@@ -219,8 +235,10 @@ class TestPluginFactories:
             with MiniPHAL(
                 plugin_ids=["bad-plugin"],
                 plugin_factories={"bad-plugin": bad_factory},
+                tolerate_load_errors=True,
             ) as phal:
                 assert "bad-plugin" not in phal._loaded
+                assert phal.load_errors
         assert any("bad-plugin" in str(warning.message) for warning in w)
 
     def test_phal_test_plugin_factories_field(self):


### PR DESCRIPTION
Fixes 16 defect groups found by an automated expert audit (behavioral, concurrency, and resilience analysts) of the ovoscope package:

**Teardown & global state**
- `End2EndTest.execute()` / `from_message()` / `MockOCPTest` now tear down MiniCroft in `finally` — a failing assertion no longer leaks patched process-globals (SessionManager.bus, Configuration, pipeline/blacklists) into later tests
- The process-wide default `Session` is snapshotted at boot and fully restored in `stop()` (incl. `active_skills` mutated via `inject_active` or session-less messages); fixes the pre-existing `test_default_pipeline_overrides_default_session` failure
- Mock-TTS timers are tracked, daemonized, and cancelled in `stop()` — no more orphaned timers emitting on a closed bus and corrupting the global SessionManager mid-later-test
- `_shared_minicroft` (intent_cases) keeps at most one live cached instance and stops them at exit; m2v sync listeners are removed and the 3.5s pad only applies when no activity was seen

**Correctness of verdicts and reports**
- Bus-coverage reports now use a per-test delta instead of session-cumulative counts (later tests were inflated by earlier tests' traffic)
- `PipelineHarness.match()`: `mycroft.skill.handler.start` no longer treated as failure (it fires on success); real matches win over concurrent failure signals; the 20Hz-forever watcher thread is gone; `assert_no_match` now fails on timeout instead of passing vacuously
- `CaptureSession`: atomic eof-counter reset, capture timeout surfaced as an explicit "capture timed out" assertion instead of a baffling count mismatch, `finish()` returns a copy
- `cmd_run` reuses the already-booted MiniCroft instead of booting a second one over the same globals
- OCP HTTP mock now sees the request URL (previously no configured URL ever matched); OCP execute waits on the query response event instead of sleeping half the timeout

**Error propagation & resource lifecycle**
- PHAL plugin load failures raise by default (`tolerate_load_errors=False`), with load errors quoted in assert failures when tolerated
- `wait_for_match` gained an `emit=` parameter (docstring previously described an impossible single-threaded call order); match/failure race hardened
- Harness `__exit__`s close buses and remove capture handlers even when shutdown raises (audio, PHAL, voice_loop, listener)
- `MiniSimpleListener.feed_file` replaces a wedged listener thread instead of reusing it (silent cross-run message pollution)
- coverage.py records pyproject/setup parse failures in the report instead of silently understating coverage
- `RemoteRecorder.connect()` closes the bus client on timeout instead of leaking a reconnecting thread

**Tests**: 40 adversarial regression tests (one per defect, written to fail against pre-fix code). Note: the local shared venv gained unrelated editable plugin installs mid-campaign that make some MiniCroft boots slow/flaky locally (fails on pristine dev too); clean CI is the arbiter here. Known upstream follow-up tracked for round 2: MiniCroft instances retain ~650MB after stop() (reference leak).

Bugs found by automated expert audit; fixes implemented by Claude (opus), orchestrated by Claude Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer pipeline outcomes for matches, explicit no-match results, and timeouts.
  * Added configurable handling for plugin load errors.
  * Coverage reports now include parsing errors.
  * Added support for TOML parsing on Python 3.10.

* **Bug Fixes**
  * Improved timeout, event matching, playback, listener, recording, and teardown reliability.
  * Prevented state, messages, timers, and coverage data from leaking between test runs.
  * Improved HTTP mocking and synchronous response handling.
  * Added comprehensive regression coverage for lifecycle and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->