### PR TITLE
fix: MiniCroft boots against older ovos-core SkillManager (backwards compat)

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import dataclasses
 import json
 import threading
@@ -502,13 +503,35 @@ class MiniCroft(SkillManager):
         self.skill_ids = skill_ids
         self.extra_skills = extra_skills or {}
 
+        # Older ovos-core SkillManager releases (e.g. the stable release
+        # channel's 1.3.x) predate some of these keyword arguments. Passing an
+        # unknown kwarg to them raises TypeError and MiniCroft cannot boot,
+        # which makes the latest ovoscope unusable against an older core (the
+        # conformance harness exercises exactly this against pinned stable /
+        # testing stacks). Forward only the enable_* flags the *installed*
+        # SkillManager actually accepts, so one ovoscope boots on every core.
+        _enable_flags = {
+            "enable_installer": enable_installer,
+            "enable_skill_api": enable_skill_api,
+            "enable_file_watcher": enable_file_watcher,
+            "enable_intent_service": enable_intent_service,
+            "enable_event_scheduler": enable_event_scheduler,
+        }
         try:
-            super().__init__(bus, enable_installer=enable_installer,
-                             enable_skill_api=enable_skill_api,
-                             enable_file_watcher=enable_file_watcher,
-                             enable_intent_service=enable_intent_service,
-                             enable_event_scheduler=enable_event_scheduler,
-                             *args, **kwargs)
+            _accepted = inspect.signature(SkillManager.__init__).parameters
+        except (ValueError, TypeError):
+            _accepted = {}
+        _has_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD
+                          for p in _accepted.values())
+        _supported = {k: v for k, v in _enable_flags.items()
+                      if _has_var_kw or k in _accepted}
+        _dropped = [k for k in _enable_flags if k not in _supported]
+        if _dropped:
+            LOG.debug(f"installed SkillManager does not accept {_dropped}; "
+                      f"omitting for backwards compatibility")
+
+        try:
+            super().__init__(bus, *args, **_supported, **kwargs)
         except Exception:
             # If super().__init__ fails (e.g. plugin construction error),
             # ensure global Configuration() is restored.

--- a/test/unittests/test_minicroft.py
+++ b/test/unittests/test_minicroft.py
@@ -431,5 +431,45 @@ class TestMiniCroftNamespaceBridging(unittest.TestCase):
             mc.stop()
 
 
+class TestSkillManagerKwargCompat(unittest.TestCase):
+    """The latest ovoscope must boot against older ovos-core SkillManager
+    releases that predate newer ``enable_*`` keyword arguments (the stable
+    release channel ships ovos-core 1.3.x, whose SkillManager has no
+    ``enable_installer``). MiniCroft must forward only the flags the installed
+    SkillManager actually accepts instead of raising TypeError and failing to
+    boot."""
+
+    def test_unsupported_enable_kwargs_are_dropped(self):
+        import ovoscope
+        from unittest.mock import patch
+
+        captured = {}
+
+        class _Reached(Exception):
+            """Raised from the fake old __init__ once kwarg filtering passed."""
+
+        # Simulate an OLD SkillManager whose signature lacks enable_installer,
+        # enable_file_watcher, enable_intent_service and enable_event_scheduler.
+        def old_init(self, bus=None, enable_skill_api=True):
+            captured["bus"] = bus
+            captured["enable_skill_api"] = enable_skill_api
+            raise _Reached
+
+        with patch.object(ovoscope.SkillManager, "__init__", old_init):
+            # If filtering failed, old_init would get enable_installer=... and
+            # raise TypeError *before its body* -> captured stays empty.
+            try:
+                MiniCroft([SKILL_ID])
+            except Exception:
+                pass
+
+        self.assertTrue(
+            captured,
+            "SkillManager.__init__ was never reached: an unsupported kwarg "
+            "was forwarded, so the latest ovoscope cannot boot on older core")
+        self.assertTrue(captured["enable_skill_api"],
+                        "a supported enable_* flag must still be forwarded")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The conformance harness (`ovos-test-harness` / `hivemind-test-harness`) installs `ovoscope@dev` and runs it against **pinned release-channel stacks** (`constraints-stable.txt` → `ovos-core 1.3.x`, `constraints-testing.txt` → `ovos-core 2.1.x`). On the **stable** channel every MiniCroft-booting conformance module errored at `setUpModule`:

```
TypeError: SkillManager.__init__() got an unexpected keyword argument 'enable_installer'
```

`MiniCroft.__init__` forwards `enable_installer`, `enable_file_watcher`, `enable_intent_service`, `enable_event_scheduler`, `enable_skill_api` to `SkillManager` **unconditionally**. `ovos-core 1.3.x`'s `SkillManager` predates some of these kwargs, so `super().__init__` raises and MiniCroft cannot boot — the latest ovoscope is unusable against an older core.

This surfaced when the harness's ovoscope pin moved from an old `<1.0.0` version (which predated these kwargs) to `@dev`.

## Fix

Forward only the `enable_*` flags the **installed** `SkillManager` actually accepts, determined by `inspect.signature` (a `**kwargs` signature accepts all). One ovoscope now boots on every supported core; modern cores are unaffected (they accept all five, so the call is byte-equivalent to before).

## Test

`TestSkillManagerKwargCompat` simulates an old `SkillManager` signature lacking `enable_installer` and asserts MiniCroft reaches `super().__init__` (no TypeError) while still forwarding the supported flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older core versions by automatically filtering unsupported configuration options during startup.
  * Preserved supported options while safely handling implementations that accept additional settings.
  * Added logging when options are omitted due to compatibility limitations.

* **Tests**
  * Added coverage confirming startup works correctly with older component versions and supported options remain enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->