### PR TITLE
fix: resolve unbounded get_response() hang on FakeBus

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -306,6 +306,7 @@ class MiniCroft(SkillManager):
                  pipeline_config: Optional[Dict[str, Dict]] = None,
                  modernize: bool = True,
                  emit_legacy: bool = True,
+                 get_response_timeout: float = 2.0,
                  *args, **kwargs):
         # Namespace-migration flags forwarded to the harness FakeBus so callers
         # can choose which bus namespace(s) to exercise:
@@ -379,6 +380,28 @@ class MiniCroft(SkillManager):
         # test. Track them so stop() can cancel them.
         self._tts_timers: List[threading.Timer] = []
         self._tts_timers_lock = threading.Lock()
+
+        # get_response()/ask_yesno() spawn a killable background thread
+        # (OVOSSkill._real_wait_response) and the calling thread busy-polls
+        # for its result. With `num_retries=-1` (the OVOSSkill default) that
+        # thread re-prompts and waits forever if nothing ever answers it —
+        # there is no ceiling on the calling thread's wait either. On a real
+        # voice satellite this eventually gets a `mycroft.skills.abort_question`
+        # from the listener/GUI on user silence or session teardown; the
+        # synchronous FakeBus never generates one. Track the pending
+        # "wait for an answer" timers here so stop() can cancel them the same
+        # way it cancels the mock-TTS ones.
+        # Keyed by (skill_id, session_id) — the SAME two-part scope upstream's
+        # own @killable_event("mycroft.skills.abort_question",
+        # check_skill_id=True) uses to decide which stalled thread an abort
+        # is actually for (session_id match + optional skill_id match). A
+        # flat list here would let one skill's `.disable` cancel a DIFFERENT
+        # skill's (or a different concurrent session's) still-pending
+        # watchdog, leaving it to hang forever again in a multi-skill
+        # MiniCroft where two get_response() calls are in flight at once.
+        self._get_response_timeout = get_response_timeout
+        self._get_response_timers: Dict[tuple, threading.Timer] = {}
+        self._get_response_timers_lock = threading.Lock()
         # Guards the `_stopped` flag against the mock-TTS emits. A plain
         # `if not self._stopped: bus.emit(...)` is a TOCTOU: stop() can flip the
         # flag and close the bus between the check and the emit, so the emit
@@ -499,6 +522,68 @@ class MiniCroft(SkillManager):
             timer.start()
 
         bus.on(SpecMessage.SPEAK, _mock_tts)
+
+        # get_response()/ask_yesno() mock: OVOSSkill.get_response() emits
+        # "skill.converse.get_response.enable" and then blocks the calling
+        # thread until a "<skill_id>.converse.get_response" answer arrives or
+        # the killable thread is aborted via "mycroft.skills.abort_question".
+        # If a test doesn't inject a follow-up utterance, nothing ever answers
+        # it and (with the OVOSSkill default `num_retries=-1`) the skill
+        # re-prompts and waits forever. Arm a short watchdog on `.enable`
+        # that fires the SAME "mycroft.skills.abort_question" a real listener
+        # would send on user silence — this is existing bus-protocol, not a
+        # new message type. "`.disable" (emitted once get_response() actually
+        # returns, whether answered or cancelled) cancels the watchdog.
+        def _arm_get_response_watchdog(message):
+            with self._stop_lock:
+                if self._stopped:
+                    return
+                skill_id = message.data.get("skill_id")
+                session_id = SessionManager.get(message).session_id
+                key = (skill_id, session_id)
+
+                def _abort():
+                    with self._stop_lock:
+                        if self._stopped:
+                            return
+                        with self._get_response_timers_lock:
+                            # Already disarmed (answered/cancelled) between
+                            # the Timer firing and this lock — nothing to do.
+                            if self._get_response_timers.get(key) is not timer:
+                                return
+                            del self._get_response_timers[key]
+                        bus.emit(message.forward("mycroft.skills.abort_question",
+                                                 {"skill_id": skill_id}))
+
+                timer = threading.Timer(self._get_response_timeout, _abort)
+                timer.daemon = True
+                with self._get_response_timers_lock:
+                    old = self._get_response_timers.get(key)
+                    if old is not None and old.is_alive():
+                        old.cancel()
+                    self._get_response_timers[key] = timer
+                timer.start()
+
+        def _disarm_get_response_watchdog(message):
+            # This ONE get_response() call returned (answered, cancelled,
+            # retries exhausted, or already aborted by our own watchdog) —
+            # cancel only ITS entry. Other (skill_id, session_id) pairs with
+            # their own in-flight get_response() must keep their watchdog
+            # armed (this is exactly what the flat-list version got wrong:
+            # any skill's `.disable` cancelled every pending watchdog).
+            skill_id = message.data.get("skill_id")
+            session_id = SessionManager.get(message).session_id
+            key = (skill_id, session_id)
+            with self._get_response_timers_lock:
+                timer = self._get_response_timers.pop(key, None)
+            if timer is not None:
+                try:
+                    timer.cancel()
+                except Exception:
+                    pass
+
+        bus.on("skill.converse.get_response.enable", _arm_get_response_watchdog)
+        bus.on("skill.converse.get_response.disable", _disarm_get_response_watchdog)
 
         self.skill_ids = skill_ids
         self.extra_skills = extra_skills or {}
@@ -679,6 +764,10 @@ class MiniCroft(SkillManager):
             # "default" session onto the process-wide SessionManager).
             with self._tts_timers_lock:
                 timers, self._tts_timers = self._tts_timers, []
+            with self._get_response_timers_lock:
+                gr_timers = list(self._get_response_timers.values())
+                self._get_response_timers = {}
+        timers = timers + gr_timers
         for t in timers:
             try:
                 t.cancel()

--- a/test/unittests/test_tts_lifecycle_nested_and_get_response.py
+++ b/test/unittests/test_tts_lifecycle_nested_and_get_response.py
@@ -1,0 +1,282 @@
+"""Regression tests for OpenVoiceOS/ovos-skill-alerts#138 (Update 3):
+
+ovoscope's synchronous FakeBus never completes the TTS handshake for
+NESTED speak calls, and never resolves an unanswered get_response()/
+ask_yesno() flow, so real skill handlers hang under the harness.
+
+Both tests must complete quickly (well under the 15-20s upstream ceilings)
+rather than hang.
+
+Also covers the follow-up defect found in adversarial review of ovoscope
+PR #130: the FIRST version of the get_response watchdog kept ONE flat list
+of pending timers, so ANY skill's `.disable` cancelled EVERY other skill's
+still-pending watchdog too. In a fleet-style MiniCroft running multiple
+skills concurrently, skill A finishing its (answered) get_response() would
+silently disarm skill B's watchdog, and if B's question was never answered
+it would hang forever again — exactly the bug this file exists to prevent.
+The fix scopes each watchdog by (skill_id, session_id), the same two-part
+scope `ovos_workshop`'s own
+`@killable_event("mycroft.skills.abort_question", check_skill_id=True)`
+already uses to decide which stalled thread an abort is actually for.
+"""
+import threading
+import time
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovos_workshop.skills.ovos import OVOSSkill
+from ovos_utils.log import LOG
+
+from ovoscope import get_minicroft, MiniCroft
+
+NESTED_SKILL_ID = "ovoscope-unittest-nested-speak.test"
+GETRESPONSE_SKILL_ID = "ovoscope-unittest-get-response.test"
+CONCURRENT_SKILL_A = "ovoscope-unittest-get-response-a.test"
+CONCURRENT_SKILL_B = "ovoscope-unittest-get-response-b.test"
+
+
+class NestedSpeakSkill(OVOSSkill):
+    """Mirrors ovos-skill-alerts' _get_response_cascade shape: a handler that
+    calls speak_dialog(..., wait=True) from INSIDE another handler that itself
+    already spoke, so the second wait_while_speaking() has to resolve against
+    a speak emitted mid-handler on the same thread."""
+
+    def initialize(self):
+        self.add_event("unittest.nested_speak", self.handle_outer)
+
+    def handle_inner(self, message: Message):
+        # Nested call: this speak_dialog happens DURING handle_outer, after
+        # handle_outer's own speak has already ducked/unducked once.
+        self.speak("inner reply", wait=True)
+
+    def handle_outer(self, message: Message):
+        self.speak("outer reply", wait=True)
+        self.handle_inner(message)
+        self.bus.emit(message.forward("unittest.nested_speak.done"))
+
+
+class GetResponseSkill(OVOSSkill):
+    """Calls get_response() and never gets an answer from the test — mirrors
+    ask_yesno()/get_response() call sites in ovos-skill-alerts that hang
+    forever with the OVOSSkill default num_retries=-1."""
+
+    def initialize(self):
+        self.add_event("unittest.ask_something", self.handle_ask)
+
+    def handle_ask(self, message: Message):
+        ans = self.get_response("give me an answer")
+        self.bus.emit(message.forward("unittest.ask_something.done",
+                                      {"answer": ans}))
+
+
+class TestNestedSpeakDialogWait(unittest.TestCase):
+    """Reproduces ovos-skill-alerts#138 mechanism (a)."""
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_nested_speak_dialog_wait_completes_quickly(self):
+        mc = get_minicroft([NESTED_SKILL_ID],
+                           extra_skills={NESTED_SKILL_ID: NestedSpeakSkill})
+        try:
+            done = []
+            mc.bus.on("unittest.nested_speak.done", lambda m: done.append(m))
+
+            start = time.time()
+            mc.bus.emit(Message("unittest.nested_speak"))
+            deadline = start + 10
+            while not done and time.time() < deadline:
+                time.sleep(0.05)
+            elapsed = time.time() - start
+
+            self.assertTrue(done, "nested speak_dialog(wait=True) never "
+                                  "completed within 10s (would be a hang "
+                                  "under the unfixed FakeBus, capped at "
+                                  "2x15s=30s upstream)")
+            # each wait_while_speaking should resolve off the mock-TTS's
+            # ~0.1s unduck timer, not burn its full 15s default timeout.
+            self.assertLess(elapsed, 2.0,
+                            f"nested speak_dialog(wait=True) took {elapsed:.2f}s; "
+                            f"expected < 2s if audio_output_end fires promptly "
+                            f"for the nested speak too")
+        finally:
+            mc.stop()
+
+
+class TestUnansweredGetResponse(unittest.TestCase):
+    """Reproduces ovos-skill-alerts#138 mechanism (b)."""
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    def test_unanswered_get_response_resolves_promptly(self):
+        mc = get_minicroft([GETRESPONSE_SKILL_ID],
+                           extra_skills={GETRESPONSE_SKILL_ID: GetResponseSkill})
+        try:
+            done = []
+            mc.bus.on("unittest.ask_something.done", lambda m: done.append(m))
+
+            start = time.time()
+            mc.bus.emit(Message("unittest.ask_something"))
+            deadline = start + 10
+            while not done and time.time() < deadline:
+                time.sleep(0.05)
+            elapsed = time.time() - start
+
+            self.assertTrue(done, "get_response() with no injected answer "
+                                  "never resolved within 10s - this is the "
+                                  "unbounded OVOSSkill._wait_response() hang")
+            self.assertIsNone(done[0].data.get("answer"),
+                              "unanswered get_response() should resolve to "
+                              "None (aborted), not a fabricated answer")
+            self.assertLess(elapsed, 5.0,
+                            f"unanswered get_response() took {elapsed:.2f}s; "
+                            f"expected the watchdog abort well under 5s")
+        finally:
+            mc.stop()
+
+
+class GetResponseSkillNamed(OVOSSkill):
+    """Same as GetResponseSkill but the class doesn't hardcode skill_id, so
+    two instances can be registered as two distinct skills in one MiniCroft
+    (extra_skills maps skill_id -> class, and OVOSSkill picks up skill_id
+    from the registration)."""
+
+    def initialize(self):
+        # Skill-scoped event name: "unittest.ask_something" (shared, unscoped)
+        # would make BOTH skill instances react to a single emit, since
+        # add_event registers on the bus's global topic namespace, not per
+        # skill. Two skills firing off the SAME incoming message defeats the
+        # point of the concurrency test (it stops being "two independent
+        # requests," it becomes one request fanned out to both skills).
+        self.add_event(f"{self.skill_id}.ask_something", self.handle_ask)
+
+    def handle_ask(self, message: Message):
+        ans = self.get_response("give me an answer")
+        self.bus.emit(message.forward(f"{self.skill_id}.ask_something.done",
+                                      {"answer": ans}))
+
+
+class TestConcurrentGetResponseWatchdogScoping(unittest.TestCase):
+    """Whitebox: directly drive the enable/disable protocol messages the way
+    OVOSSkill.get_response() emits them, without waiting on real timers, to
+    pin the exact defect found in review: a flat timer list lets one skill's
+    `.disable` wipe out every other skill's still-armed watchdog."""
+
+    def setUp(self):
+        LOG.set_level("ERROR")
+
+    def tearDown(self):
+        LOG.set_level("CRITICAL")
+
+    @staticmethod
+    def _enable_message(skill_id: str, session_id: str) -> Message:
+        sess = Session(session_id=session_id)
+        return Message("skill.converse.get_response.enable",
+                       {"skill_id": skill_id},
+                       {"session": sess.serialize()})
+
+    @staticmethod
+    def _disable_message(skill_id: str, session_id: str) -> Message:
+        sess = Session(session_id=session_id)
+        return Message("skill.converse.get_response.disable",
+                       {"skill_id": skill_id},
+                       {"session": sess.serialize()})
+
+    def test_disabling_one_skill_does_not_cancel_another_skills_watchdog(self):
+        mc = get_minicroft([])
+        try:
+            mc.bus.emit(self._enable_message("skillA", "sessA"))
+            mc.bus.emit(self._enable_message("skillB", "sessB"))
+            # Both must be armed before either is disabled.
+            self.assertEqual(2, len(mc._get_response_timers))
+
+            mc.bus.emit(self._disable_message("skillA", "sessA"))
+
+            # THE DEFECT (flat list): this drops to 0 - skillB's watchdog is
+            # gone too. THE FIX (keyed by (skill_id, session_id)): only
+            # skillA's entry is removed, skillB's stays armed.
+            self.assertEqual(
+                1, len(mc._get_response_timers),
+                "disabling skillA's get_response must not cancel skillB's "
+                "still-pending watchdog")
+            remaining_key = next(iter(mc._get_response_timers))
+            self.assertEqual(("skillB", "sessB"), remaining_key)
+            self.assertTrue(mc._get_response_timers[remaining_key].is_alive())
+        finally:
+            mc.stop()
+
+    def test_unanswered_skill_still_aborted_when_another_skill_answers_first(self):
+        """End-to-end concurrent scenario: skill A gets answered quickly via
+        a real injected utterance; skill B never gets an answer. B's own
+        watchdog must still fire and abort it - A finishing first must not
+        silently leave B hanging."""
+        mc = get_minicroft(
+            [CONCURRENT_SKILL_A, CONCURRENT_SKILL_B],
+            extra_skills={CONCURRENT_SKILL_A: GetResponseSkillNamed,
+                         CONCURRENT_SKILL_B: GetResponseSkillNamed})
+        try:
+            done_a, done_b = [], []
+            mc.bus.on(f"{CONCURRENT_SKILL_A}.ask_something.done",
+                     lambda m: done_a.append(m))
+            mc.bus.on(f"{CONCURRENT_SKILL_B}.ask_something.done",
+                     lambda m: done_b.append(m))
+
+            sess_a = Session(session_id="concurrent-sess-a")
+            sess_b = Session(session_id="concurrent-sess-b")
+
+            # Kick off both get_response() calls concurrently on separate
+            # threads, mirroring two independent skills/sessions in flight
+            # in a real fleet-style MiniCroft at the same time.
+            t_a = threading.Thread(
+                target=lambda: mc.bus.emit(Message(
+                    f"{CONCURRENT_SKILL_A}.ask_something", {},
+                    {"session": sess_a.serialize(), "skill_id": CONCURRENT_SKILL_A})))
+            t_b = threading.Thread(
+                target=lambda: mc.bus.emit(Message(
+                    f"{CONCURRENT_SKILL_B}.ask_something", {},
+                    {"session": sess_b.serialize(), "skill_id": CONCURRENT_SKILL_B})))
+            t_a.start()
+            t_b.start()
+
+            # Give both get_response() calls a moment to reach their
+            # listening state, then answer ONLY A - B is deliberately left
+            # unanswered so its own watchdog has to do the work.
+            time.sleep(0.3)
+            mc.bus.emit(Message(
+                f"{CONCURRENT_SKILL_A}.converse.get_response",
+                {"utterances": ["forty two"]},
+                {"session": sess_a.serialize()}))
+
+            t_a.join(timeout=10)
+            t_b.join(timeout=10)
+
+            deadline = time.time() + 10
+            while (not done_a or not done_b) and time.time() < deadline:
+                time.sleep(0.05)
+
+            self.assertTrue(done_a, "skill A's answered get_response() "
+                                    "never resolved")
+            self.assertTrue(done_b, "skill B's unanswered get_response() "
+                                    "never resolved - its watchdog was "
+                                    "cancelled by skill A's .disable "
+                                    "(the flat-list defect)")
+            self.assertEqual("forty two", done_a[0].data.get("answer"),
+                            "skill A's legitimate answer must survive "
+                            "skill B's watchdog/abort handling untouched")
+            self.assertIsNone(done_b[0].data.get("answer"),
+                              "skill B was never answered, so it must "
+                              "resolve to None via its OWN watchdog abort")
+        finally:
+            mc.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

**Revised after adversarial review** — see "Concurrency defect found in review" below.

## Field evidence

OpenVoiceOS/ovos-skill-alerts#138 ("Update 3") root-caused, via py-spy stack
captures on a real CI hang, two mechanisms by which real skill handlers
block forever under ovoscope's synchronous FakeBus:

- **(a)** `wait_while_speaking()` (`ovos_bus_client/session.py:710`) burns
  its full 15s timeout for nested/cascading `speak_dialog(..., wait=True)`
  calls if `recognizer_loop:audio_output_end` never arrives. Already
  mitigated in `ovoscope/__init__.py`'s `_mock_tts` mock-TTS handler
  (per-call `threading.Timer` unduck) — verified still correct for nested
  calls (see regression test below).
- **(b)** `OVOSSkill._wait_response()` (`ovos_workshop/skills/ovos.py`
  ~1802-1809, `ovos-workshop==7.0.6`) has **no deadline at all**:
  `while not ans: time.sleep(0.1)`. With the `get_response()`/`ask_yesno()`
  default `num_retries=-1`, the background `_real_wait_response` thread
  re-prompts forever if nothing ever answers it. A real voice satellite
  eventually emits `mycroft.skills.abort_question` on user silence;
  ovoscope's FakeBus never did. This is what leaked non-answered-thread
  state into `ovos-skill-alerts`' shared-MiniCroft e2e suite and made CI
  hang to the 30-minute job kill on 4 of 5 Python versions on PR #123.

## Fix

`MiniCroft` arms a short watchdog `threading.Timer` on
`skill.converse.get_response.enable` that emits the **existing**
`mycroft.skills.abort_question` bus message (no new message type — this is
the same message a real listener/GUI sends on cancel/silence, and
`OVOSSkill._real_wait_response` is already decorated with
`@killable_event("mycroft.skills.abort_question", ...)` to handle it) if
`.disable` doesn't fire first. `.disable` (emitted once `get_response()`
actually returns, answered or not) disarms the watchdog. Tracked/cancelled
in `stop()` the same way the existing mock-TTS timers already are, so no
orphaned timer can fire onto a closed bus and poison a later test.

### Concurrency defect found in review

The first version of this fix kept ONE flat list of pending watchdog
timers. Adversarial review reproduced a real regression: with two
concurrent `get_response()` flows in flight (skill A and skill B, a
fleet-style MiniCroft running multiple skills), skill A's `.disable`
**drained and cancelled the entire list**, including skill B's still-armed
watchdog — if B's question was never answered, B hung forever again,
defeating the fix for exactly the multi-skill case it needs to hold up
under. Repro that pinned it: `enable(A)`, `enable(B)`, `disable(A)` → `0`
timers left instead of `1`.

Fixed by scoping each watchdog by `(skill_id, session_id)` — the same
two-part scope `ovos_workshop`'s own
`@killable_event("mycroft.skills.abort_question", check_skill_id=True)`
already uses to decide which stalled thread an abort is actually for.
`.disable` now cancels only its own `(skill_id, session_id)` entry; the
abort emit carries the same `skill_id`/session context so only the
stalled question dies. `stop()` still drains and cancels every remaining
entry on teardown.

Smallest correct change: `ovoscope/__init__.py` only (`MiniCroft`),
mirroring the existing `_mock_tts` timer-tracking pattern already in the
file.

## Red → green proof

`test/unittests/test_tts_lifecycle_nested_and_get_response.py`:

- `TestNestedSpeakDialogWait` / `TestUnansweredGetResponse` — the original
  two regression tests. Before the fix: both hang (a 90s `timeout` kill was
  needed to get a shell back). After: both pass in ~3s.
- `TestConcurrentGetResponseWatchdogScoping` (new, pins the review finding):
  - `test_disabling_one_skill_does_not_cancel_another_skills_watchdog` —
    whitebox, drives the `enable`/`disable` protocol messages directly.
    **On the flat-list version this FAILS**: `AssertionError: 1 != 0`
    (skill B's watchdog is gone after only skill A disabled). On the fixed
    version it passes.
  - `test_unanswered_skill_still_aborted_when_another_skill_answers_first`
    — end-to-end: two skills, two sessions, concurrent `get_response()`
    calls; skill A is answered via an injected utterance, skill B is
    deliberately left unanswered. **On the flat-list version this hangs**
    (verified via a 20s `timeout` kill on the whole test class). On the
    fixed version: skill A's real answer survives untouched, skill B is
    aborted by its own watchdog and resolves to `None` — both complete in
    ~7s total for the 4-test file.

## Full `ovoscope` suite (after fix)

```
1 failed, 626 passed, 13 skipped, 3200 warnings in 151.77s
FAILED test/unittests/test_tts_intelligibility.py::TestHarnessPlaybackMode::test_playback_captures_wav_and_scores
```

That one failure is a pre-existing order-dependent flake, unrelated to
this change: it passes in isolation and doesn't touch
`get_response`/`speak_dialog` mocking at all. Reproduces the same way with
the fix reverted.

## Real-world gate: ovos-skill-alerts PR #123

Checked out `OpenVoiceOS/ovos-skill-alerts` PR #123
(`feat/ovoscope-tests`) into a separate throwaway clone/venv (Python
3.14 in this sandbox), installed this branch's `ovoscope` via local path,
and ran its `test/end2end` suite (`ovos-workshop`/`ovos-core`/`padacioso`
pipeline — `ovos-padatious` still not installable on this box, matching
the maintainer's own note in #138).

- **Before** (issue #138's documented CI evidence, Python 3.10/3.12-3.14):
  job hangs to the 30-minute `timeout-minutes` kill.
- **After** (this fix, this sandbox, serial): `30 failed, 3 passed, 133
  skipped in ~12s` — **terminates, no hang**. The failures are the
  already-documented, unrelated auto-generation defects from #138 Update 1
  (utterances that don't satisfy the pinned adapt pipeline's
  `.require(...)` vocab) — out of scope here.

Note: this sandbox's exact pass/fail counts differ from the numbers seen
in review logs on a Python 3.11 + `pytest-xdist` setup (`1 failed, 32
passed, 133 skipped in ~24s`) — re-ran with `pytest-xdist` here too and
still saw the pre-existing vocab-mismatch failures, just distributed
differently across workers (`30 failed, 2 passed, 52 skipped in ~19s`, same
"terminates, no hang" outcome). The discrepancy tracks Python version /
worker distribution affecting which of the *already-documented, unrelated*
vocab-pinning tests execute — it does not affect the property this PR
claims: the suite reliably terminates instead of hanging.

## Scope

Only `ovoscope/__init__.py` (`MiniCroft`) changed, plus the regression
test. No new bus message types. No changes to `ovos-workshop` (out of
scope for this repo — the `_wait_response()` no-deadline issue is a
separate upstream defect worth its own report there, not fixed here).
