### PR TITLE
fix: remove _TolerantPlaylist shim now that ovos-media 0.4.3a1 fixes Playlist crash

### DIFF
--- a/ovoscope/media.py
+++ b/ovoscope/media.py
@@ -340,30 +340,12 @@ class OCPPlayerHarness:
         gui_mock = MagicMock()
         self.gui = gui_mock
 
-        # Patch Playlist so that Playlist("Search Results") doesn't try to
-        # add the string as a media entry.  The installed ovos_utils.ocp.Playlist
-        # treats all positional args as entries; we need a subclass that silently
-        # drops bare string args (which are titles, not entries) and still
-        # satisfies isinstance(x, Playlist) checks inside player.py.
-        from ovos_utils.ocp import Playlist as _RealPlaylist
-
-        class _TolerantPlaylist(_RealPlaylist):
-            """Playlist subclass that ignores bare string constructor args."""
-
-            def __init__(self, *args, **kwargs):
-                valid = [a for a in args if not isinstance(a, str)]
-                super().__init__(*valid, **kwargs)
-
         # Every mock.patch below is process-wide until stopped. If anything
         # after the first start() raises (a missing ovos_media attribute, a
         # backend constructor error), an unguarded exit would leave those
         # patches active for the rest of the process and silently corrupt
         # every later test. Unwind through __exit__ before propagating.
         try:
-            p_playlist = patch("ovos_media.player.Playlist", _TolerantPlaylist)
-            p_playlist.start()
-            self._patches.append(p_playlist)
-
             simple_targets = [
                 "ovos_media.player.AudioService",
                 "ovos_media.player.VideoService",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pydantic = ["ovos-pydantic-models>=0.1.0"]
 # ovos-spec-tools 0.10.0a1, so that is the real floor.
 audio = ["ovos-audio>=1.3.0a1", "ovos-spec-tools>=0.10.0a1"]
 # OCP / ovos-media player harnesses (ovoscope.media: OCPPlayerHarness, ...).
-media = ["ovos-media>=0.0.2a3"]
+media = ["ovos-media>=0.4.3a1"]
 # MiniListener plugin_instances path (feed_audio_stream) needs the dinkum
 # AudioTransformersService. >=0.7.2a1 is the first release that allows
 # ovos-bus-client 2.x (older pins cap it <2.0.0 and conflict with ovos-core).
@@ -64,7 +64,7 @@ tts = [
 ]
 dev = [
     "ovos-audio>=1.3.0a1",
-    "ovos-media>=0.0.2a3",
+    "ovos-media>=0.4.3a1",
     "ovos-dinkum-listener>=0.7.2a1",
     "ovos-pydantic-models>=0.1.0",
     "numpy",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This removes _TolerantPlaylist, a patched-in Playlist subclass the test harness used to silently drop bare string arguments so that constructing the default playlist wouldn't crash. It existed because the installed ovos-media had a real bug — Playlist("Search Results") crashed at construction, tracked as ovos-media#96 — and this shim let the harness boot despite that, at the cost of hiding any future regression of exactly that bug from everyone using the harness.

ovos-media 0.4.3a1, now on PyPI, actually fixes the crash. With the real fix in place, keeping the shim does nothing useful anymore — it just masks the exact same class of bug if it ever comes back. So this removes the shim and raises the harness's ovos-media floor to that fixed version, letting the harness construct the real, unpatched player so any future regression shows up as a test failure instead of silence.

Tested in two throwaway venvs. With the fixed ovos-media version and the shim removed, the full suite gave 9 failures out of 621 passed and 13 skipped — all 9 reproduce identically against the unmodified harness in the same venv, so they predate this change and have nothing to do with the shim, Playlist, or the harness class it patches. The harness's own test file alone passed cleanly, 32 of 32. As a negative control, the same removal was tested against the older, broken ovos-media version, and it failed exactly as expected — 6 of the harness's own tests failed with the precise crash the shim used to hide, confirming the shim really was masking that bug and not something incidental. No other references to the shim exist anywhere else in the repo.

One open item: this PR's build-tests failures are a known pre-existing class of MiniCroft boot-leak failures that reproduce identically even with the shim still in place — a separate PR (#134) addresses that class. This should be rebased and re-run once #134 lands, and shouldn't be merged red in the meantime.
