### PR TITLE
fix: accept canonical spec topics in captured-stream assertions

### DIFF
--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -18,6 +18,7 @@ from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import ProcessState
 from ovos_spec_tools import SpecMessage
+from ovos_spec_tools.messages import MIGRATION_MAP, SPEC_TO_LEGACY
 from ovos_workshop.skills.api import SkillApi
 from ovos_workshop.skills.ovos import OVOSSkill
 
@@ -1093,6 +1094,34 @@ class CaptureSession:
             pass
 
 
+def _topic_matches(msg_type: str, name: str) -> bool:
+    """True if ``msg_type`` is ``name`` under either its legacy or canonical spelling.
+
+    Producers emit canonical ``ovos.*`` spec topics since workshop#425, but
+    ovoscope's ``execute()`` captures every message via the bus catch-all
+    (faithfully to the real wire), so a pre-spec producer vintage in the
+    captured stream can still carry the legacy name instead. Assertions that
+    filter the captured stream by ``msg_type`` must therefore accept both
+    spellings.
+
+    The legacy<->canonical pairing is not hand-rolled here: it reuses the
+    same static maps ``ovos-bus-client``'s ``MessageBusClient`` and
+    ``ovos-utils``' ``FakeBus`` use for their dual-emit bridging (see
+    ``ovos_spec_tools.messages.NamespaceTranslator`` /
+    ``MIGRATION_MAP`` / ``SPEC_TO_LEGACY``), so the pairing can't drift out
+    of sync with the real bus behaviour.
+    """
+    if msg_type == name:
+        return True
+    canonical = MIGRATION_MAP.get(name)
+    if canonical is not None and msg_type == canonical.value:
+        return True
+    legacy = SPEC_TO_LEGACY.get(name)
+    if legacy is not None and msg_type == legacy:
+        return True
+    return False
+
+
 @dataclasses.dataclass()
 class End2EndTest:
     skill_ids: List[str]  # skill_ids to load during the test (from skill plugins)
@@ -1571,7 +1600,7 @@ class End2EndTest:
         speak_utterances = [
             m.data.get("utterance")
             for m in messages
-            if m.msg_type == "speak" and m.data.get("lang") == lang
+            if _topic_matches(m.msg_type, "speak") and m.data.get("lang") == lang
         ]
         assert text in speak_utterances, (
             f"❌ speak '{text}' (lang={lang}) not found. "

--- a/ovoscope/pydantic_helpers.py
+++ b/ovoscope/pydantic_helpers.py
@@ -85,7 +85,11 @@ def to_bus_message(pydantic_msg: "OpenVoiceOSMessage") -> Message:
         from ovos_pydantic_models import SpeakMessage, SpeakData
 
         bus_msg = to_bus_message(SpeakMessage(data=SpeakData(utterance="Hello!")))
-        assert bus_msg.msg_type == "speak"
+        # Accepts both the legacy "speak" and canonical "ovos.utterance.speak"
+        # spellings (producers emit canonical since workshop#425; captured
+        # streams from pre-spec producer vintages can still carry the legacy
+        # name).
+        assert bus_msg.msg_type in {"speak", "ovos.utterance.speak"}
         assert bus_msg.data["utterance"] == "Hello!"
     """
     _require_pydantic()

--- a/ovoscope/voice_loop.py
+++ b/ovoscope/voice_loop.py
@@ -61,6 +61,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 
+from ovoscope import _topic_matches
+
 # Re-export the engine mocks so callers have a single import site for the
 # voice-loop harness.
 from ovoscope.listener import MockHotWordEngine, MockVADEngine  # noqa: F401
@@ -549,7 +551,11 @@ class ListenerHarness:
 
     @staticmethod
     def _has(messages: List[Message], msg_type: str) -> bool:
-        return any(m.msg_type == msg_type for m in messages)
+        # Accepts either the legacy or canonical spelling of msg_type — see
+        # ovoscope._topic_matches: these helpers filter execute()/feed_*()'s
+        # catch-all-captured stream, which can carry either spelling
+        # depending on producer vintage.
+        return any(_topic_matches(m.msg_type, msg_type) for m in messages)
 
     def _resolve(self, messages: Optional[List[Message]]) -> List[Message]:
         return messages if messages is not None else self._last_messages
@@ -654,7 +660,7 @@ class ListenerHarness:
         msgs = self._resolve(messages)
         utts: List[str] = []
         for m in msgs:
-            if m.msg_type == "recognizer_loop:utterance":
+            if _topic_matches(m.msg_type, "recognizer_loop:utterance"):
                 utts.extend(m.data.get("utterances", []))
         assert utts, (
             "Expected 'recognizer_loop:utterance' but it was not emitted. "

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
@@ -84,7 +85,7 @@ def _make_custom(msg_type: str, data=None,
 _FAILURE_SEQ = [
     # message itself is index 0 (caller provides it)
     Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-    Message("complete_intent_failure", {}),
+    Message("ovos.intent.unmatched", {}),
     Message("ovos.utterance.handled", {}),
 ]
 
@@ -147,7 +148,7 @@ class TestExecuteReturnValue(unittest.TestCase):
         result = test.execute(timeout=10)
         types = [m.msg_type for m in result]
         self.assertIn("unittest.echo", types)
-        self.assertIn("speak", types)
+        self.assertIn("ovos.utterance.speak", types)
         self.assertIn("ovos.utterance.handled", types)
 
     def test_execute_result_length_matches_expected(self):
@@ -165,7 +166,7 @@ class TestExecuteReturnValue(unittest.TestCase):
             source_message=src,
             expected_messages=[
                 src,
-                Message("speak", {"utterance": "count test"}),
+                Message("ovos.utterance.speak", {"utterance": "count test"}),
                 Message("ovos.utterance.handled", {}),
             ],
             # filter out handler.start / handler.complete so count is 3
@@ -290,7 +291,7 @@ class TestAssertions(unittest.TestCase):
     def test_ignore_messages_excluded_from_captured_list(self):
         """Messages in ignore_messages do not appear in the captured sequence."""
         src = _make_custom("unittest.echo", {"text": "filter"})
-        # Add "speak" to ignored — only 2 messages remain: src + eof
+        # Add "ovos.utterance.speak" to ignored — only 2 messages remain: src + eof
         test = End2EndTest(
             minicroft=self.mc,
             skill_ids=[SKILL_ID],
@@ -299,7 +300,7 @@ class TestAssertions(unittest.TestCase):
                 src,
                 Message("ovos.utterance.handled", {}),
             ],
-            ignore_messages=["ovos.skills.settings_changed", "speak"]
+            ignore_messages=["ovos.skills.settings_changed", "ovos.utterance.speak"]
                             + HANDLER_LIFECYCLE,
             test_routing=False,
             test_active_skills=False,
@@ -332,7 +333,7 @@ class TestManagedLifecycle(unittest.TestCase):
             expected_messages=[
                 message,
                 Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-                Message("complete_intent_failure", {}),
+                Message("ovos.intent.unmatched", {}),
                 Message("ovos.utterance.handled", {}),
             ],
             flip_points=["recognizer_loop:utterance"],
@@ -391,6 +392,29 @@ class TestAssertSpoke(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self._spoke_test("correct text").assert_spoke("WRONG TEXT", timeout=10)
 
+    def test_assert_spoke_accepts_canonical_only_captured_stream(self):
+        """assert_spoke matches a captured stream that only carries the
+        canonical "ovos.utterance.speak" topic (post-workshop#425 producers).
+        """
+        test = self._spoke_test("canonical text")
+        captured = [
+            Message("ovos.utterance.speak",
+                    {"utterance": "canonical text", "lang": "en-US"}),
+        ]
+        with patch.object(End2EndTest, "execute", return_value=captured):
+            test.assert_spoke("canonical text", timeout=10)
+
+    def test_assert_spoke_accepts_legacy_only_captured_stream(self):
+        """assert_spoke matches a captured stream that only carries the
+        legacy "speak" topic (pre-spec producer vintage on the wire).
+        """
+        test = self._spoke_test("legacy text")
+        captured = [
+            Message("speak", {"utterance": "legacy text", "lang": "en-US"}),
+        ]
+        with patch.object(End2EndTest, "execute", return_value=captured):
+            test.assert_spoke("legacy text", timeout=10)
+
 
 # ---------------------------------------------------------------------------
 # Tests: serialization round-trip (serialize / deserialize / save / from_path)
@@ -418,7 +442,7 @@ class TestSerialization(unittest.TestCase):
             expected_messages=[
                 src,
                 Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-                Message("complete_intent_failure", {}),
+                Message("ovos.intent.unmatched", {}),
                 Message("ovos.utterance.handled", {}),
             ],
             flip_points=["recognizer_loop:utterance"],
@@ -510,11 +534,11 @@ class TestMultiTurn(unittest.TestCase):
             expected_messages=[
                 turn1,
                 Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-                Message("complete_intent_failure", {}),
+                Message("ovos.intent.unmatched", {}),
                 Message("ovos.utterance.handled", {}),
                 turn2,
                 Message("mycroft.audio.play_sound", {"uri": "snd/error.mp3"}),
-                Message("complete_intent_failure", {}),
+                Message("ovos.intent.unmatched", {}),
                 Message("ovos.utterance.handled", {}),
             ],
             flip_points=["recognizer_loop:utterance"],

--- a/test/unittests/test_end2end_extended.py
+++ b/test/unittests/test_end2end_extended.py
@@ -624,7 +624,7 @@ class TestVerboseOutput(unittest.TestCase):
             source_message=src,
             expected_messages=[
                 src,
-                Message("speak", {"utterance": "verbose"}),
+                Message("ovos.utterance.speak", {"utterance": "verbose"}),
                 Message("ovos.utterance.handled", {}),
             ],
             ignore_messages=DEFAULT_IGNORED + HANDLER_LIFECYCLE,

--- a/test/unittests/test_voice_loop.py
+++ b/test/unittests/test_voice_loop.py
@@ -29,6 +29,7 @@ from ovos_bus_client.message import Message
 from ovos_spec_tools import SpecMessage
 
 from ovoscope.voice_loop import (
+    ListenerHarness,
     MiniHotwordContainer,
     MiniVoiceLoop,
     MockHotWordEngine,
@@ -371,6 +372,46 @@ class TestMiniVoiceLoopNamespaceBridging(unittest.TestCase):
             self.assertTrue(legacy_hits, "legacy record_begin should still fire")
             self.assertEqual(spec_hits, [],
                              "spec topic must not fire with bridging off")
+
+
+class TestAssertionHelpersAcceptCanonicalTopics(unittest.TestCase):
+    """The assert_*_emitted/suppressed helpers filter a catch-all-captured
+    stream (same defect class as ovoscope.assert_spoke) — they must accept
+    canonical spec topics, not just the legacy recognizer_loop:* spellings.
+    """
+
+    def test_assert_record_begin_emitted_accepts_canonical_only_stream(self):
+        harness = ListenerHarness()
+        captured = [Message("ovos.listener.record.started")]
+        harness.assert_record_begin_emitted(captured)  # must not raise
+
+    def test_assert_wakeword_detected_accepts_canonical_only_stream(self):
+        harness = ListenerHarness()
+        captured = [
+            Message("recognizer_loop:wakeword"),  # not migrated — legacy only
+            Message("ovos.listener.record.started"),
+        ]
+        harness.assert_wakeword_detected(captured)  # must not raise
+
+    def test_assert_utterance_emitted_accepts_canonical_only_stream(self):
+        harness = ListenerHarness()
+        captured = [Message("ovos.utterance.handle", {"utterances": ["hi"]})]
+        harness.assert_utterance_emitted("hi", captured)  # must not raise
+
+    def test_assert_wakeword_suppressed_still_fails_on_canonical_record_begin(self):
+        """Regression for the negative-assertion false-GREEN: a canonical-only
+        captured stream that DOES contain a record-begin must still fail
+        assert_wakeword_suppressed, not silently pass because the helper only
+        recognised the legacy spelling.
+        """
+        harness = ListenerHarness()
+        captured = [Message("ovos.listener.record.started")]
+        with self.assertRaises(AssertionError):
+            harness.assert_wakeword_suppressed(captured)
+
+    def test_assert_wakeword_suppressed_passes_on_truly_empty_stream(self):
+        harness = ListenerHarness()
+        harness.assert_wakeword_suppressed([])  # must not raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Root cause

Producers emit canonical `ovos.*` spec topics since workshop#425. `End2EndTest.execute()`
captures the bus via a catch-all subscriber (faithfully to the real wire), so a captured
stream can carry either the canonical name or, from a pre-spec producer vintage, the legacy
name. Two assertion helpers filtered that captured stream by the hard-coded legacy `"speak"`
spelling only, so they broke against canonical-only captured streams (e.g. current
`ovos-core`/`ovos-workshop`, which now emit `ovos.utterance.speak`).

## Fix

Dual-name tolerance in the library, canonical spelling in fixtures/tests:

- `ovoscope/__init__.py`: added a module-level `_topic_matches(msg_type, name)` helper.
  Rather than hand-rolling a legacy↔canonical pair list, it reuses
  `ovos_spec_tools.messages.MIGRATION_MAP` / `SPEC_TO_LEGACY` — the same static maps
  `ovos-bus-client`'s `MessageBusClient` and `ovos-utils`' `FakeBus` use for their own
  dual-emit bridging (`NamespaceTranslator.counterpart_topics`) — so the pairing can't drift
  out of sync with real bus behaviour. `assert_spoke()` now uses `_topic_matches(m.msg_type,
  "speak")` instead of `m.msg_type == "speak"`.
- `ovoscope/voice_loop.py`: `ListenerHarness._has()` (used by
  `assert_record_begin_emitted`/`assert_wakeword_detected`/`assert_wakeword_suppressed`) and
  `assert_utterance_emitted()`'s inline `msg_type ==` check now route through `_topic_matches`
  too — same catch-all-captured-stream defect as `assert_spoke`. This mattered most for
  `assert_wakeword_suppressed`, which asserts the *negative*: on the legacy-only check, a
  canonical-only captured stream containing a real record-begin would silently pass (false
  green) instead of failing. `recognizer_loop:record_begin`/`record_end`/`utterance` do have
  canonical counterparts in `MIGRATION_MAP` (`ovos.listener.record.started/ended`,
  `ovos.utterance.handle`); `recognizer_loop:wakeword` has no canonical counterpart and stays
  legacy-only — `_topic_matches` falls back to an exact match for it, so behaviour there is
  unchanged.

**Not a functional fix, correcting the earlier revision of this description:**
`ovoscope/pydantic_helpers.py`'s change is a **docstring-example edit only** — it makes the
`to_bus_message()` docstring's illustrative `assert` accept either spelling for readability.
The actual runtime assertion (`test/unittests/test_pydantic_helpers.py:44`) still checks
`bus_msg.msg_type == "speak"` and is correctly left as-is: `to_bus_message()` converts a
`SpeakMessage` pydantic model to a `Message`, and that model's `message_type` is a fixed,
model-deterministic value — not a captured, vintage-dependent stream — so there is no
legacy/canonical ambiguity to tolerate there.

### Sweep of other hard-coded legacy-topic comparisons against captured streams

Grepped `__init__.py`, `audio.py`, `media.py`, `ocp.py`, `voice_loop.py`, `phal.py`, `e2e.py`
for `msg_type ==` comparisons against known migrated legacy names (`speak`,
`complete_intent_failure`, `recognizer_loop:*`, etc.):

- **Changed**: `assert_spoke()` (`__init__.py`), and — added after adversarial review flagged
  the initial sweep missed it — `ListenerHarness._has()` / `assert_utterance_emitted()`
  (`voice_loop.py`). All filter a catch-all-captured stream.
- **Left alone, deliberately**:
  - `e2e.py`'s `complete_intent_failure` checks (`_wait_for_expected_or_fail`,
    `assert_fail_response`, etc.) are all direct `bus.on("complete_intent_failure", ...)`
    subscriptions, not catch-all-captured-stream filters — `FakeBus` mirrors dual-emit
    per-subscriber, so a handler subscribed to the legacy name still fires on a canonical
    emission. No change needed.
  - `listener.py`'s `recognizer_loop:utterance` comparisons are inside module docstring
    usage examples only — not executable assertion code — so there is nothing to fix there.
    (`voice_loop.py`'s equivalent helpers, by contrast, are real public assertion API that
    filters a live captured stream — the initial sweep wrongly lumped the two together and
    skipped `voice_loop.py`; adversarial review caught it, fixed above.)
  - `ocp.py` (`ovos.common_play.*`) and `audio.py` (`mycroft.audio.service.*`,
    `SpecMessage.AUDIO_OUTPUT_*`) topics are not in `MIGRATION_MAP` — no legacy/canonical
    ambiguity exists for them.

### Stale fixtures

`test/unittests/test_end2end.py` and `test_end2end_extended.py` had 7 tests whose expected-
message fixtures hard-coded the legacy `"speak"` / `"complete_intent_failure"` spellings,
which now mismatch the canonical topics the venv's `ovos-core`/`ovos-workshop` actually
emit. Updated all fixture literals (`Message("speak", ...)` → `Message("ovos.utterance.speak",
...)`, `Message("complete_intent_failure", ...)` → `Message("ovos.intent.unmatched", ...)`,
plus the matching `ignore_messages`/`assertIn` string literals) to canonical.

### New regression tests

Added to `TestAssertSpoke` in `test/unittests/test_end2end.py`:

- `test_assert_spoke_accepts_canonical_only_captured_stream` — captured stream contains
  only `"ovos.utterance.speak"`.
- `test_assert_spoke_accepts_legacy_only_captured_stream` — captured stream contains only
  `"speak"`.

Both mock `End2EndTest.execute()` to return a synthetic captured stream, isolating the
assertion logic from a live `MiniCroft` boot.

## Red/green evidence

Stashed only the two library files (`ovoscope/__init__.py`, `ovoscope/pydantic_helpers.py`),
keeping the new tests, and ran `TestAssertSpoke`:

```
FAILED test_assert_spoke_accepts_canonical_only_captured_stream
FAILED test_assert_spoke_passes_correct_utterance   (live MiniCroft now emits canonical)
2 failed, 2 passed
```

Restored the fix:

```
test_assert_spoke_accepts_canonical_only_captured_stream PASSED
test_assert_spoke_accepts_legacy_only_captured_stream    PASSED
test_assert_spoke_fails_wrong_utterance                  PASSED
test_assert_spoke_passes_correct_utterance               PASSED
4 passed
```

Full `test_end2end.py` + `test_end2end_extended.py`: **62 passed** (was 7 failed / 55 passed
before this fix).

### voice_loop.py regression (added after adversarial review)

New `TestAssertionHelpersAcceptCanonicalTopics` in `test/unittests/test_voice_loop.py`, run
against `ListenerHarness` directly (no live `MiniVoiceLoop`/dinkum boot needed) with a
synthetic captured stream. With only `ovoscope/voice_loop.py` stashed (unfixed helper):

```
FAILED test_assert_record_begin_emitted_accepts_canonical_only_stream
FAILED test_assert_utterance_emitted_accepts_canonical_only_stream
FAILED test_assert_wakeword_detected_accepts_canonical_only_stream
FAILED test_assert_wakeword_suppressed_still_fails_on_canonical_record_begin
4 failed, 1 passed
```

The 4th one is the important negative-assertion regression: on the unfixed helper,
`assert_wakeword_suppressed` did **not** raise on a canonical-only stream containing a real
`ovos.listener.record.started` — a false green. Restored the fix:

```
5 passed
```

`assert_wakeword_suppressed` now correctly raises `AssertionError` on that same input.

### Full suite

Full `test/unittests` suite (run file-by-file — some individual files take 20–100s to boot a
real `MiniCroft`, and combining all files in one pytest process in this particular throwaway
venv triggers an unrelated cross-file timing issue unless run in smaller batches):
**514 passed, 9 failed, 117 skipped** (`test_wakeword_probe.py` also errors at collection).
All 9 failures + the collection error are pre-existing and unrelated to this change —
reproduced identically with the library changes stashed (`test_audit_round1.py::
TestHarnessTeardown` x2, `test_listener_stream.py` x7, `test_wakeword_probe.py` collection
error), most plausibly a missing/mismatched optional dependency (`numpy`/audio-stream
extras) in this throwaway venv.

## Downstream spot-check

Cloned `OpenVoiceOS/ovos-skill-hello-world`, installed this branch's `ovoscope` (editable)
plus `test/requirements-end2end.txt`, ran `test/end2end`:

```
19 passed, 2 failed
```

The 2 failures (`TestAdaptIntent::test_adapt_match`, `TestPadatiousIntent::test_padatious_match`)
are a message-count mismatch (12 received vs 10 expected — extra
`recognizer_loop:audio_output_start/end` messages) caused by a version-skew between the
throwaway venv's installed plugin set and hello-world's own pins — **not** a topic-name
mismatch. Confirmed pre-existing: reproduced identically with the released PyPI
`ovoscope==1.6.6a1` (i.e. without this fix) swapped in for the same spot-check run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message validation now recognizes both legacy and canonical topic names.
  * Speech, utterance, wake-word, and recording assertions work consistently across supported message formats.
  * Improved compatibility for end-to-end and voice-loop message detection.

* **Tests**
  * Added regression coverage for canonical and legacy topic handling.
  * Updated expectations to reflect current canonical message topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->