### PR TITLE
fix: raise clear TypeError for bare-string expected_messages

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -37,17 +37,34 @@ pytest test/end2end/ -v --timeout=60
 
 ```python
 from ovoscope import End2EndTest, get_minicroft
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+SKILL_ID = "skill-id.author"
 
 # Start MiniCroft with your skill
-minicroft = get_minicroft(["skill-id.author"])
+minicroft = get_minicroft([SKILL_ID])
 
-# Define and run a test
-test = End2EndTest(
-    utterance="hello world",
-    skill_id="skill-id.author",
-    expected_messages=["speak"],
+session = Session("test-session")
+utterance = Message(
+    "recognizer_loop:utterance",
+    {"utterances": ["hello world"], "lang": "en-US"},
+    {"session": session.serialize(), "source": "A", "destination": "B"},
 )
-test.execute(minicroft)
+
+# Define and run a test. expected_messages must be Message instances (not
+# bare topic strings) — use the canonical ovos.* spec topic (OVOS-PIPELINE-1)
+# for the speak response.
+test = End2EndTest(
+    minicroft=minicroft,
+    skill_ids=[SKILL_ID],
+    source_message=utterance,
+    expected_messages=[
+        utterance,
+        Message("ovos.utterance.speak", {"utterance": "hello"}),
+    ],
+)
+test.execute()
 ```
 
 ### Record a Fixture (CLI)

--- a/ovoscope/__init__.py
+++ b/ovoscope/__init__.py
@@ -1216,6 +1216,27 @@ class End2EndTest:
         # would leave a single (non-iterable) Message and break later iteration.
         if not isinstance(self.source_message, list):
             self.source_message = [self.source_message]
+
+        # expected_messages (and expected_boot_sequence) must be Message
+        # objects: execute() reads .msg_type / .data / .context off every
+        # entry while walking the captured stream. A bare topic string (e.g.
+        # expected_messages=["speak"]) used to fail deep in that loop with an
+        # obscure AttributeError ('str' object has no attribute 'msg_type'/
+        # 'serialize') instead of naming the actual mistake at construction
+        # time. Message objects were the only shape this dataclass ever
+        # accepted (unchanged since the first commit) — fail fast and clearly
+        # instead.
+        for _field_name in ("expected_messages", "expected_boot_sequence"):
+            for _i, _m in enumerate(getattr(self, _field_name)):
+                if not isinstance(_m, Message):
+                    raise TypeError(
+                        f"❌ {_field_name}[{_i}] must be a Message instance, "
+                        f"got {type(_m).__name__}: {_m!r}. Bare topic strings "
+                        f"(e.g. expected_messages=[\"speak\"]) are not "
+                        f"supported — build a Message(topic, data, context) "
+                        f"for each expected entry."
+                    )
+
         if self.ignore_gui:
             # ensure we don't mutate a shared default list
             self.ignore_messages = list(self.ignore_messages)

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -212,6 +212,35 @@ class TestAssertions(unittest.TestCase):
         defaults.update(overrides)
         return defaults
 
+    def test_expected_messages_bare_string_raises_clear_type_error(self):
+        """A bare topic string in expected_messages (e.g. ["speak"]) must
+        raise a clear TypeError naming the mistake at construction time,
+        never an obscure AttributeError deep inside execute()'s assertion
+        loop. Message objects are, and have always been, the only accepted
+        shape for this field."""
+        src = _make_custom("unittest.echo", {"text": "string test"})
+        with self.assertRaises(TypeError):
+            End2EndTest(
+                minicroft=self.mc,
+                skill_ids=[SKILL_ID],
+                source_message=src,
+                expected_messages=["speak"],
+                **self._base_flags(),
+            )
+
+    def test_expected_boot_sequence_bare_string_raises_clear_type_error(self):
+        """Same guard applies to expected_boot_sequence."""
+        src = _make_custom("unittest.echo", {"text": "boot string test"})
+        with self.assertRaises(TypeError):
+            End2EndTest(
+                minicroft=self.mc,
+                skill_ids=[SKILL_ID],
+                source_message=src,
+                expected_messages=[],
+                expected_boot_sequence=["mycroft.ready"],
+                **self._base_flags(),
+            )
+
     def test_wrong_message_count_raises(self):
         """test_message_number=True raises AssertionError on count mismatch."""
         src = _make_custom("unittest.echo", {"text": "count"})


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## What

`End2EndTest.execute()` reads `.msg_type` / `.data` / `.context` / `.serialize()`
off every entry of `expected_messages` (and `expected_boot_sequence`) while
walking the captured message stream. A bare topic string, e.g.
`expected_messages=["speak"]`, was never a supported shape for that field —
but nothing enforced it at construction time, so it fell through and blew up
deep inside `execute()`'s assertion loop with an obscure
`AttributeError: 'str' object has no attribute 'msg_type'` (or `'serialize'`,
depending which check ran first).

This adds a validation step in `__post_init__` that rejects non-`Message`
entries in `expected_messages`/`expected_boot_sequence` with a `TypeError`
that names the offending index, the type actually passed, and what's
expected — at construction time, before `execute()` ever runs.

## API-history verdict

**Bare topic strings were never an accepted shape for `expected_messages`.**

- `git blame`/`git log -S` on the assertion line (`expected.msg_type ==
  received.msg_type`) show it dates back to the very first commit
  (`d3280ab`) — attribute access on `expected` has always been there.
- Checked real usage across the org (`gh search code "expected_messages"
  org:OpenVoiceOS`): every current call site that constructs an
  `End2EndTest` directly (docs/usage-guide.md, docs/index.md,
  docs/gui-testing.md, README.md, ovos-skill-laugh, ovos-skill-parrot,
  ovos-skill-ddg, ovos-skill-camera, ovos-skill-application-launcher, ...)
  builds full `Message(...)` objects.
- `SKILL.md` in this repo does show `expected_messages=["speak"]`, but that
  example is already stale/broken independent of this bug — it also uses
  `utterance=`/`skill_id=` kwargs that don't exist on the current
  `End2EndTest` dataclass at all (`source_message`/`skill_ids` are the real
  fields). It documents an API that was never implemented as written, so
  it isn't evidence the string shape was ever live.
- The `"expected_messages": ["speak"]` entries in various skills'
  `golden_utterances.jsonl` fixtures (dictation, wikipedia, ddg, wikihow,
  wallpapers, application-launcher, ...) are not passed to `End2EndTest`
  at all — the loader tests I checked (e.g. `ovos-skill-ddg/test/end2end/
  test_golden_utterances.py`) use `CaptureSession` directly and check
  `msg_type` membership manually; the JSONL field is informational.
- Checked the reported origin (`ovos-skill-alerts` end2end suite,
  `test/end2end/test_intents_en_us.py`): it doesn't use `End2EndTest` or
  `expected_messages` at all either — it also drives `CaptureSession`
  directly with manual `assertIn`/`assertTrue` checks.

No downstream caller relies on the string shape, so this PR does not
restore string support — it just fails fast and clearly instead of
crashing obscurely, per the regression-test requirement either way.

## Testing

- New tests in `test/unittests/test_end2end.py::TestAssertions`:
  `test_expected_messages_bare_string_raises_clear_type_error` and
  `test_expected_boot_sequence_bare_string_raises_clear_type_error`.
- Verified red-before (`AssertionError: TypeError not raised` against
  unmodified `dev`) / green-after (both pass) by stashing/restoring just
  the `ovoscope/__init__.py` fix.
- Full `test/unittests` suite: **526 passed** (524 baseline + 2 new),
  same **9 pre-existing failures** reproduced identically on unmodified
  `dev` HEAD (`b9beab2`) before touching anything — `test_audit_round1.py`
  (2) and `test_listener_stream.py` (7), untouched by this change.
- Baseline collection error from missing `numpy` (bench extra) resolved
  by installing it in the throwaway venv; not a code issue.

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
