### PR TITLE
fix: assert canonical suffixless intent ids in intent_cases

### DIFF
--- a/docs/intent-cases.md
+++ b/docs/intent-cases.md
@@ -33,8 +33,8 @@ register_intent_case_tests(
     globals(),
     skill_id="ovos-skill-personal.openvoiceos",
     handlers={
-        "WhoAreYou.intent": "PersonalSkill.handle_who_are_you_intent",
-        "WhatAreYou.intent": "PersonalSkill.handle_what_are_you_intent",
+        "WhoAreYou": "PersonalSkill.handle_who_are_you_intent",
+        "WhatAreYou": "PersonalSkill.handle_what_are_you_intent",
     },
     cases_dir=Path(__file__).parent / "cases",
 )
@@ -58,12 +58,12 @@ Frozen dataclass: a single expectation — `utterance` in `lang` should match
 |---|---|---|
 | `lang` | `str` | Language directory the case came from. |
 | `utterance` | `str` | The utterance text. |
-| `intent` | `Optional[str]` | Expected `"<IntentName>.intent"`, or `None` to assert the utterance falls through to `complete_intent_failure`. |
+| `intent` | `Optional[str]` | Expected canonical intent name (`"<IntentName>"`, the `.intent` suffix is folded off), or `None` to assert the utterance falls through to `complete_intent_failure`. |
 | `source` | `Path` | The `.test` file the case was read from. |
 
 ## `load_intent_cases(cases_dir, known_intents=None) -> List[IntentCase]`
 Discover every `IntentCase` under `cases_dir`. Returns `[]` if `cases_dir`
-does not exist. If `known_intents` is given, every `<Intent>.intent`
+does not exist. If `known_intents` is given, every discovered intent name (suffix folded)
 filename found is validated against it — a typo raises `AssertionError`
 instead of being silently skipped.
 

--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -1,0 +1,14 @@
+# Pre-release quirks
+
+Behavior changes since the last stable release, newest first. This file is
+reset at each stable release.
+
+## next alpha
+
+- `intent_cases` now asserts the OVOS-INTENT-4 canonical (suffixless) intent
+  id: matcher plugins (ovos-padatious 2.0+) fold the legacy `<file>.intent`
+  suffix off at registration, so the expected dispatch topic is
+  `<skill_id>:<IntentName>`, not `<skill_id>:<IntentName>.intent`. Case files
+  keep their `<Intent>.intent.test` naming; suffixed entries in
+  `known_intents` and `handlers` are still accepted and folded the same way,
+  so existing suites keep working unchanged.

--- a/ovoscope/intent_cases.py
+++ b/ovoscope/intent_cases.py
@@ -31,8 +31,8 @@ Usage (one call, in a test module owned by the skill)
         globals(),
         skill_id="ovos-skill-personal.openvoiceos",
         handlers={
-            "WhoAreYou.intent": "PersonalSkill.handle_who_are_you_intent",
-            "WhatAreYou.intent": "PersonalSkill.handle_what_are_you_intent",
+            "WhoAreYou": "PersonalSkill.handle_who_are_you_intent",
+            "WhatAreYou": "PersonalSkill.handle_what_are_you_intent",
             # ...
         },
         cases_dir=Path(__file__).parent / "cases",
@@ -107,6 +107,17 @@ class IntentCase:
 # ---------------------------------------------------------------------------
 # Case-file discovery
 # ---------------------------------------------------------------------------
+def canonical_intent(name):
+    """Fold the legacy ``<file>.intent`` id onto the OVOS-INTENT-4 canonical
+    suffixless id. Matcher plugins (ovos-padatious >= 2.0) dealias at
+    registration, so engine matches carry the suffixless name; case files keep
+    the ``<Intent>.intent.test`` naming, and suffixed entries in
+    ``known_intents``/``handlers`` are accepted and folded the same way."""
+    if name and name.endswith(".intent"):
+        return name[:-len(".intent")]
+    return name
+
+
 def _read_lines(path: Path) -> List[str]:
     out: List[str] = []
     for raw in path.read_text(encoding="utf-8").splitlines():
@@ -134,7 +145,8 @@ def load_intent_cases(cases_dir: Union[str, Path],
     base = Path(cases_dir)
     if not base.is_dir():
         return []
-    known = set(known_intents) if known_intents is not None else None
+    known = ({canonical_intent(i) for i in known_intents}
+             if known_intents is not None else None)
     cases: List[IntentCase] = []
     for lang_dir in sorted(base.iterdir()):
         if not lang_dir.is_dir() or lang_dir.name.startswith("_"):
@@ -144,7 +156,8 @@ def load_intent_cases(cases_dir: Union[str, Path],
             if case_file.name == "no_match.test":
                 expected: Optional[str] = None
             elif case_file.stem.endswith(".intent"):
-                expected = case_file.stem  # "<IntentName>.intent"
+                # engine matches are suffixless (OVOS-INTENT-4 canonical id)
+                expected = canonical_intent(case_file.stem)
                 if known is not None and expected not in known:
                     raise AssertionError(
                         f"{case_file} targets unknown intent "
@@ -215,6 +228,7 @@ def assert_intent_case(minicroft, skill_id: str, handlers: Dict[str, str],
             test_msg_context=False,
         )
     else:
+        handlers = {canonical_intent(k): v for k, v in handlers.items()}
         if case.intent not in handlers:
             raise AssertionError(
                 f"No handler mapping for intent {case.intent!r} "

--- a/test/unittests/test_intent_cases.py
+++ b/test/unittests/test_intent_cases.py
@@ -35,6 +35,20 @@ class TestLoadIntentCases(TestCase):
             self.assertEqual(len(cases), 3)
             self.assertEqual(sum(1 for c in cases if c.intent is None), 1)
             self.assertTrue(all(c.lang == "en-US" for c in cases))
+            # case ids are the OVOS-INTENT-4 canonical (suffixless) form the
+            # matcher plugins actually register, regardless of whether the
+            # caller's known_intents entries carry the legacy suffix
+            self.assertEqual({c.intent for c in cases if c.intent},
+                             {"WhoAreYou"})
+
+    def test_suffixless_known_intents_accepted(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            self._write(tmp, "en-US", "WhoAreYou.intent.test", "who are you\n")
+            cases = load_intent_cases(tmp / "cases",
+                                      known_intents=["WhoAreYou"])
+            self.assertEqual(cases[0].intent, "WhoAreYou")
 
     def test_unknown_intent_raises(self):
         import tempfile


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`intent_cases` built the expected dispatch topic as `<skill_id>:<IntentName>.intent`, keeping the case file's suffix. Matcher plugins fold that legacy suffix off at registration (ovos-padatious 2.0+, `_dealias_intent_name`), so engine matches are suffixless and the helper's assertion failed for every skill using it — ovos-skill-personal currently works around this with a local fork of the helper that also loses the final-session assertions.

The fix mirrors the dealias rule: a `canonical_intent` helper folds the `.intent` suffix off the derived case id, the `known_intents` validation set, and the `handlers` keys, so both suffixed and suffixless caller inputs keep working while assertions target the canonical id. Case files keep their `<Intent>.intent.test` naming. The docstring example and docs page now show suffixless handler keys.

Regression tests pin the canonical id and the suffixless-inputs path; verified fail-before by patch-revert (2 failures on the unfixed helper). The wider unit suite is unchanged outside `intent_cases` (the listener-stream/audio-harness failures in a minimal local venv are environment-dependent and untouched by this diff — CI is authoritative there). Docs: `docs/prerelease-quirks.md` entry added.
