### PR TITLE
fix: harness duck/unduck emit spec audio-output topics

### DIFF
--- a/docs/media-testing.md
+++ b/docs/media-testing.md
@@ -97,8 +97,15 @@ in ``PLAYING`` state; only the audio backend volume is reduced.
 
 | Bus message | Handler | Effect |
 |---|---|---|
-| `recognizer_loop:audio_output_start` / `ovos.common_play.duck` | `handle_duck_request` | Calls `audio_service.lower_volume()`, sets `_paused_on_duck=True` |
-| `recognizer_loop:audio_output_end` / `ovos.common_play.unduck` | `handle_unduck_request` | Calls `audio_service.restore_volume()` whenever `_paused_on_duck` is True, **regardless of player state** |
+| `ovos.audio.output.started` / `ovos.common_play.duck` | `handle_duck_request` | Calls `audio_service.lower_volume()`, sets `_paused_on_duck=True` |
+| `ovos.audio.output.ended` / `ovos.common_play.unduck` | `handle_unduck_request` | Calls `audio_service.restore_volume()` whenever `_paused_on_duck` is True, **regardless of player state** |
+
+`OCPPlayerHarness.duck()`/`unduck()` emit the spec-namespace
+`ovos.audio.output.started`/`ended` — matching what the real `ovos-audio`
+service emits on every speech begin/end — rather than the legacy
+`recognizer_loop:audio_output_*` alias. The `emit_legacy` bridge (on by
+default) relays the spec emission to legacy-only subscribers, so the same
+helper drives ovos-media builds that bind either namespace.
 
 ```python
 from ovoscope.media import OCPPlayerHarness
@@ -300,8 +307,8 @@ harness drives that real backend through a real `AudioService` (see
 | `stop()` | `ovos.common_play.stop` |
 | `next_track()` | `ovos.common_play.next` |
 | `prev_track()` | `ovos.common_play.previous` |
-| `duck()` | `recognizer_loop:audio_output_start` — lower volume, player stays PLAYING |
-| `unduck()` | `recognizer_loop:audio_output_end` — restore volume whenever `_paused_on_duck` is True (duck or cork path) |
+| `duck()` | `ovos.audio.output.started` — lower volume, player stays PLAYING |
+| `unduck()` | `ovos.audio.output.ended` — restore volume whenever `_paused_on_duck` is True (duck or cork path) |
 | `cork()` | `ovos.common_play.cork` — pause player, set `_paused_on_duck=True` |
 | `uncork()` | `ovos.common_play.uncork` — resume player if PAUSED and `_paused_on_duck` |
 | `simulate_track_end()` | `ovos.common_play.media.state` END_OF_MEDIA |

--- a/ovoscope/media.py
+++ b/ovoscope/media.py
@@ -293,10 +293,14 @@ class OCPPlayerHarness:
                 bridge lets a spec-namespace producer's ovos.audio.output.* /
                 ovos.listener.record.* reach those legacy handlers.
             emit_legacy: FakeBus also emits the legacy topic when an ovos.* spec
-                topic is emitted (spec producer -> legacy listener). Because the
-                player subscribes on the legacy topics, this is the bridge that
-                connects a spec producer to the player. Set both False to exercise
-                a single namespace with no bridging.
+                topic is emitted (spec producer -> legacy listener). This is the
+                bridge that connects a spec producer to a player build that
+                binds only the legacy topics — including
+                :meth:`OCPPlayerHarness.duck`/:meth:`~OCPPlayerHarness.unduck`,
+                which emit ``ovos.audio.output.started/ended`` (matching what
+                the real ``ovos-audio`` service emits) rather than the legacy
+                aliases. Set both False to exercise a single namespace with no
+                bridging.
         """
         self.backend_namespace: str = backend_namespace
         self.backend_factory = backend_factory
@@ -500,7 +504,16 @@ class OCPPlayerHarness:
         time.sleep(0.05)
 
     def duck(self) -> None:
-        """Lower the audio backend volume via ``recognizer_loop:audio_output_start``.
+        """Lower the audio backend volume via ``ovos.audio.output.started``.
+
+        Simulates the start of TTS playback the way the real ``ovos-audio``
+        service does it: ``ovos_audio/playback.py`` emits the spec topic
+        ``ovos.audio.output.started`` unconditionally on every speech begin
+        (via ``SpecMessage``). The legacy ``recognizer_loop:audio_output_start``
+        alias is not guaranteed to be emitted, so the harness targets the spec
+        topic directly; the ``emit_legacy``/``modernize`` bridge on
+        :class:`~ovos_utils.fakebus.FakeBus` still connects it to a
+        legacy-only listener when needed.
 
         Ducking lowers volume while the voice assistant speaks.  The player
         **stays PLAYING** — only the backend volume is reduced.
@@ -509,11 +522,18 @@ class OCPPlayerHarness:
         Handler: ``OCPMediaPlayer.handle_duck_request`` —
         ``ovos_media/player.py:1216``.
         """
-        self.bus.emit(Message("recognizer_loop:audio_output_start"))
+        self.bus.emit(Message("ovos.audio.output.started"))
         time.sleep(0.05)
 
     def unduck(self) -> None:
-        """Restore the audio backend volume via ``recognizer_loop:audio_output_end``.
+        """Restore the audio backend volume via ``ovos.audio.output.ended``.
+
+        Simulates the end of TTS playback the way the real ``ovos-audio``
+        service does it: ``ovos_audio/playback.py`` emits the spec topic
+        ``ovos.audio.output.ended`` unconditionally on every speech end (via
+        ``SpecMessage``). See :meth:`duck` for why the harness targets the
+        spec topic rather than the legacy ``recognizer_loop:audio_output_end``
+        alias.
 
         Note: ``handle_unduck_request`` only restores volume when the player is
         PAUSED (``state == PlayerState.PAUSED``).  After a pure duck cycle the
@@ -523,7 +543,7 @@ class OCPPlayerHarness:
         Handler: ``OCPMediaPlayer.handle_unduck_request`` —
         ``ovos_media/player.py:1228``.
         """
-        self.bus.emit(Message("recognizer_loop:audio_output_end"))
+        self.bus.emit(Message("ovos.audio.output.ended"))
         time.sleep(0.05)
 
     def cork(self) -> None:

--- a/test/unittests/test_media.py
+++ b/test/unittests/test_media.py
@@ -360,3 +360,29 @@ class TestOCPHarnessNamespaceBridging:
             h.bus.emit(Message(str(SpecMessage.LISTENER_RECORD_STARTED)))
             time.sleep(0.2)  # give any (incorrect) bridge a chance to fire
             h.assert_player_state(PlayerState.PLAYING)
+
+
+@pytest.mark.skipif(not _HAS_OVOS_MEDIA,
+                    reason="requires the [media] extra (ovos-media)")
+class TestOCPHarnessDuckUnduckEmitsSpecTopics:
+    """``duck()``/``unduck()`` simulate what the real ``ovos-audio`` service
+    emits on speech begin/end — the spec topics ``ovos.audio.output.started``/
+    ``ended`` — not the legacy ``recognizer_loop:audio_output_*`` aliases.
+
+    Bridging is turned off here (``modernize=False, emit_legacy=False``) so
+    the assertion pins the topic the *producer* actually emits, rather than
+    one FakeBus synthesizes from the other namespace."""
+
+    def test_duck_emits_spec_topic(self) -> None:
+        with OCPPlayerHarness(modernize=False, emit_legacy=False) as h:
+            seen = []
+            h.bus.on("ovos.audio.output.started", lambda m: seen.append(m))
+            h.duck()
+            assert seen, "duck() did not emit ovos.audio.output.started"
+
+    def test_unduck_emits_spec_topic(self) -> None:
+        with OCPPlayerHarness(modernize=False, emit_legacy=False) as h:
+            seen = []
+            h.bus.on("ovos.audio.output.ended", lambda m: seen.append(m))
+            h.unduck()
+            assert seen, "unduck() did not emit ovos.audio.output.ended"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`OCPPlayerHarness.duck()` and `unduck()` simulate TTS output start/end to exercise `OCPMediaPlayer`'s duck/cork handling, but they were emitting the legacy `recognizer_loop:audio_output_start`/`_end` topics. The real `ovos-audio` service (`ovos_audio/playback.py`, `begin_audio`/`end_audio`) emits the spec topics `ovos.audio.output.started`/`ovos.audio.output.ended` unconditionally on every speech begin/end via `SpecMessage`. The legacy aliases were only ever one consumer's compatibility binding, not what the production stack actually produces.

This matters because `ovos-media` is dropping the legacy topic aliases. Against a build without them, `duck()`/`unduck()` become silent no-ops: nothing in the real stack still emits `recognizer_loop:audio_output_*`, so a harness user asserting on duck/unduck behavior would see the player never react, with no indication why. Harness consumers that relied on the legacy emission should target the spec topics going forward, the same way the real audio service does.

The fix changes `duck()`/`unduck()` to emit `ovos.audio.output.started`/`ovos.audio.output.ended` while keeping the method names and signatures, since they describe intent rather than wire format. The class docstring's `emit_legacy`/`modernize` explanation and `docs/media-testing.md` are updated to match — the harness's `emit_legacy` bridge (on by default) still relays the spec emission to `OCPMediaPlayer`'s current legacy-subscribed `handle_duck_request`/`handle_unduck_request`, so today's `ovos-media` keeps working unchanged.

No existing test exercised `duck()`/`unduck()`'s emitted topic directly, so this adds `TestOCPHarnessDuckUnduckEmitsSpecTopics` in `test/unittests/test_media.py`, with bridging turned off (`modernize=False, emit_legacy=False`) so the assertion pins what the producer itself emits rather than what FakeBus synthesizes from the other namespace. Both new tests were confirmed to fail against the pre-fix code and pass after.

The full suite (`pytest -q`) passes 641/642 collected tests plus 13 skipped, both before and after this change; the one failure (`test_tts_intelligibility.py::TestHarnessPlaybackMode::test_playback_captures_wav_and_scores`) is a pre-existing full-suite ordering flake — it passes in isolation and is untouched by this diff.
