### PR TITLE
fix: make OCPPlayerHarness tolerate ovos-media dropping GUI and per-namespace bus surfaces

### DIFF
--- a/docs/media-testing.md
+++ b/docs/media-testing.md
@@ -29,7 +29,9 @@ Wraps a real `OCPMediaPlayer` (`ovos_media.player`) with a `MockOCPBackend` on a
 - `ovos_media.player.VideoService` — mocked
 - `ovos_media.player.WebService` — mocked
 - `ovos_media.player.OcpMprisExporter` — mocked (no D-Bus session required)
-- `ovos_media.player.GUIInterface` — mocked (exposed as `harness.gui`)
+- `ovos_media.player.GUIInterface` — mocked (exposed as `harness.gui`), only
+  on `ovos-media` builds that define it; builds without in-core GUI
+  integration skip this patch
 - `ovos_media.player.OCPMediaCatalog` — mocked
 - `ovos_media.player.Configuration` — returns `{"media": {}}`
 
@@ -332,7 +334,7 @@ harness drives that real backend through a real `AudioService` (see
 | `player` | `OCPMediaPlayer` | Real player instance |
 | `bus` | `FakeBus` | Shared in-process bus |
 | `backend` | `MockOCPBackend` | Injected mock audio backend |
-| `gui` | `MagicMock` | Mocked GUIInterface |
+| `gui` | `MagicMock` | Mocked GUIInterface (unused if the `ovos-media` build has no GUI integration) |
 
 ### OCPCaptureSession
 
@@ -354,8 +356,11 @@ Default `track_prefixes` captures: `"ovos.common_play."`, `"ovos.audio."`.
   trigger end-of-track logic.
 - **No MPRIS**: `OcpMprisExporter` is mocked out — MPRIS D-Bus integration is
   not exercised.
-- **No GUI rendering**: `GUIInterface` is a `MagicMock`. Test GUI calls via
-  `harness.gui.show_media_player.assert_called_with(...)`.
+- **No GUI rendering**: on `ovos-media` builds that still define
+  `GUIInterface`, it is patched with a `MagicMock`; test GUI calls via
+  `harness.gui.show_media_player.assert_called_with(...)`. Builds without
+  in-core GUI integration have no `GUIInterface` to patch, and `harness.gui`
+  is an unused `MagicMock`.
 - **No VideoService / WebService**: Only audio playback (`PlaybackType.AUDIO`)
   is wired with a real mock backend.
 - **FakeBus is synchronous**: Handlers run in the same thread that calls

--- a/ovoscope/media.py
+++ b/ovoscope/media.py
@@ -260,7 +260,9 @@ class OCPPlayerHarness:
     - ``ovos_media.player.VideoService``
     - ``ovos_media.player.WebService``
     - ``ovos_media.player.OcpMprisExporter``
-    - ``ovos_media.player.GUIInterface``  (exposed as ``harness.gui``)
+    - ``ovos_media.player.GUIInterface``  (exposed as ``harness.gui``, when
+      the installed ``ovos-media`` still defines it — builds that have
+      dropped in-core GUI integration skip this patch)
     - ``ovos_media.player.OCPMediaCatalog``
     - ``ovos_media.player.Configuration``  (returns ``{"media": {}}``)
 
@@ -385,10 +387,15 @@ class OCPPlayerHarness:
             p_cfg.start()
             self._patches.append(p_cfg)
 
-            p_gui = patch("ovos_media.player.GUIInterface",
-                          return_value=gui_mock)
-            p_gui.start()
-            self._patches.append(p_gui)
+            # GUIInterface only exists on ovos-media builds that still carry
+            # in-core GUI integration; newer builds have dropped the symbol
+            # entirely, so patching it unconditionally would AttributeError.
+            import ovos_media.player as _ocp_player_module
+            if hasattr(_ocp_player_module, "GUIInterface"):
+                p_gui = patch("ovos_media.player.GUIInterface",
+                              return_value=gui_mock)
+                p_gui.start()
+                self._patches.append(p_gui)
 
             # Instantiate the real player (all heavy deps are now mocked)
             self.player = OCPMediaPlayer(self.bus, config={})
@@ -413,7 +420,14 @@ class OCPPlayerHarness:
                 audio_svc.default = self.backend
                 self.backend.set_track_start_callback(audio_svc.track_start)
                 # load_services() (skipped with autoload=False) would register these.
-                self.bus.on(f"ovos.{ns}.service.play", audio_svc.handle_play)
+                # handle_play routed the per-namespace ovos.{ns}.service.play bus
+                # topic on builds that had it; newer ovos-media dropped that whole
+                # per-namespace bus surface (pause/resume/stop survive as plain
+                # methods) — playback goes exclusively through OCPMediaPlayer.play()
+                # calling audio_service.play() directly, so there is nothing to
+                # register in its absence.
+                if hasattr(audio_svc, "handle_play"):
+                    self.bus.on(f"ovos.{ns}.service.play", audio_svc.handle_play)
                 self.bus.on(f"ovos.{ns}.service.pause", audio_svc.pause)
                 self.bus.on(f"ovos.{ns}.service.resume", audio_svc.resume)
                 self.bus.on(f"ovos.{ns}.service.stop", audio_svc.stop)
@@ -430,7 +444,8 @@ class OCPPlayerHarness:
                 self.backend.set_track_start_callback(audio_svc.track_start)
                 # Register the audio service bus handlers manually
                 # (normally done inside BaseMediaService.load_services)
-                self.bus.on(f"ovos.{ns}.service.play", audio_svc.handle_play)
+                if hasattr(audio_svc, "handle_play"):
+                    self.bus.on(f"ovos.{ns}.service.play", audio_svc.handle_play)
                 self.bus.on(f"ovos.{ns}.service.pause", audio_svc.pause)
                 self.bus.on(f"ovos.{ns}.service.resume", audio_svc.resume)
                 self.bus.on(f"ovos.{ns}.service.stop", audio_svc.stop)

--- a/test/unittests/test_media.py
+++ b/test/unittests/test_media.py
@@ -386,3 +386,76 @@ class TestOCPHarnessDuckUnduckEmitsSpecTopics:
             h.bus.on("ovos.audio.output.ended", lambda m: seen.append(m))
             h.unduck()
             assert seen, "unduck() did not emit ovos.audio.output.ended"
+
+
+@pytest.mark.skipif(not _HAS_OVOS_MEDIA,
+                    reason="requires the [media] extra (ovos-media)")
+class TestOCPHarnessWithoutGUIInterface:
+    """Newer ``ovos-media`` builds have dropped in-core GUI integration
+    entirely, so ``ovos_media.player`` no longer defines ``GUIInterface``.
+    The harness must still start up against such a build instead of
+    AttributeError-ing on an unconditional patch target."""
+
+    def test_enter_succeeds_when_gui_interface_symbol_is_absent(self) -> None:
+        import ovos_media.player as ocp_player_module
+
+        had_symbol = hasattr(ocp_player_module, "GUIInterface")
+        removed = None
+        if had_symbol:
+            removed = ocp_player_module.GUIInterface
+            del ocp_player_module.GUIInterface
+        try:
+            assert not hasattr(ocp_player_module, "GUIInterface")
+            with OCPPlayerHarness() as h:
+                assert h.player is not None
+        except NameError as e:
+            # An installed ovos-media that still carries in-core GUI
+            # integration references GUIInterface directly from
+            # OCPMediaPlayer.__init__, independent of the harness's own
+            # patch logic — deleting the symbol out from under it simulates
+            # a state that build can never actually be in. This scenario
+            # only exercises the harness against a build that has genuinely
+            # dropped the symbol.
+            if "GUIInterface" not in str(e):
+                raise
+            pytest.skip("installed ovos-media still uses GUIInterface "
+                        "internally; this build cannot run without it")
+        finally:
+            if had_symbol:
+                ocp_player_module.GUIInterface = removed
+
+
+@pytest.mark.skipif(not _HAS_OVOS_MEDIA,
+                    reason="requires the [media] extra (ovos-media)")
+class TestOCPHarnessWithoutHandlePlay:
+    """Newer ``ovos-media`` builds dropped the per-namespace
+    ``ovos.{ns}.service.play`` bus surface entirely — ``AudioService`` (and
+    its ``BaseMediaService`` parent) no longer define ``handle_play``;
+    ``pause``/``resume``/``stop`` survive as plain methods called directly by
+    ``OCPMediaPlayer``. The real-backend-factory path of the harness must
+    still start up, and playback must still work end-to-end, against a
+    build without ``handle_play``."""
+
+    def test_enter_and_play_succeed_when_handle_play_is_absent(self) -> None:
+        from ovos_media.media_backends.audio import AudioService
+        from ovos_media.media_backends.base import BaseMediaService
+
+        # handle_play is inherited from BaseMediaService — not AudioService's
+        # own attribute — so it must be removed at its defining class.
+        had_symbol = hasattr(BaseMediaService, "handle_play")
+        removed = None
+        if had_symbol:
+            removed = BaseMediaService.handle_play
+            del BaseMediaService.handle_play
+        try:
+            assert not hasattr(AudioService, "handle_play")
+            from ovos_utils.ocp import MediaEntry, PlaybackType
+            with OCPPlayerHarness(backend_factory=_RecordingBackend) as h:
+                assert h.player is not None
+                h.play(MediaEntry(uri="library://track/42",
+                                  playback=PlaybackType.AUDIO))
+                assert h.backend.is_playing is True
+                assert h.backend.play_calls == ["library://track/42"]
+        finally:
+            if had_symbol:
+                BaseMediaService.handle_play = removed


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-media is removing its in-core GUI integration and its per-namespace service bus surface. A build without them no longer defines `ovos_media.player.GUIInterface` or `BaseMediaService.handle_play` (inherited by `AudioService`); `pause`, `resume`, and `stop` survive as plain methods on both generations, called directly by `OCPMediaPlayer`, so they need no change. `OCPPlayerHarness.__enter__` in `ovoscope/media.py` patched `GUIInterface` and registered a bus handler for `handle_play` unconditionally, so starting the harness against a build without either symbol raised `AttributeError`/broke bus registration instead of behaving correctly. Grepping the repo for `GUIInterface`, `is_gui_connected`, `is_gui_running`, `show_media_player`, `handle_play`, and the other per-namespace `handle_*` bus handlers (`handle_track_info`, `handle_list_backends`, `handle_get_track_length`/`position`, `handle_set_track_position`, `handle_seek_forward`/`backward`) turned up no other unconditional patch or registration sites — `handle_play` was the only one of that family the harness ever touched.

The fix guards both call sites behind `hasattr()` checks: `GUIInterface` is only patched when `ovos_media.player` defines it, and the `ovos.{ns}.service.play` bus route is only registered when the backend service object defines `handle_play`. Playback keeps working either way because `OCPMediaPlayer.play()` calls `audio_service.play()` directly on both generations — the per-namespace bus route was only ever a secondary entry point for external callers, not something the harness's own control flow depends on. `docs/media-testing.md` describes the `GUIInterface` behavior in timeless language, without referencing a particular version or date.

Two new tests were added. `TestOCPHarnessWithoutGUIInterface` simulates the symbol being absent by deleting it from the live `ovos_media.player` module and asserts `__enter__` still succeeds; it skips (rather than asserting an impossible state) against an installed `ovos-media` whose own `OCPMediaPlayer.__init__` still calls `GUIInterface` directly, since deleting the symbol there simulates a state that generation can never be in. `TestOCPHarnessWithoutHandlePlay` deletes `handle_play` from `BaseMediaService` (its defining class — it isn't `AudioService`'s own attribute) and asserts both `__enter__` and a real play-through-injected-backend round trip still succeed. Both were proven red against the unfixed code via a patch-file revert of the fix (never `git stash`) before the fix was reapplied.

Full-suite results against the currently published `ovos-media` (1.0.0a1, has both symbols): 642 passed, 1 pre-existing failure (`test_tts_intelligibility.py::test_playback_captures_wav_and_scores`, a known ordering flake), 14 skipped. Against a local editable install of the in-flight `ovos-media` PR that drops both the GUI integration and the per-namespace bus surface (`OpenVoiceOS/ovos-media#153`, used only to exercise this fix, not as a dependency change): 643 passed, the same 1 known flake, 13 skipped — the two `TestOCPPlayerHarnessBackendInjection` failures observed earlier (`handle_play` AttributeError) are gone, confirmed by running them individually alongside the two new tests before the full run.

This PR is a draft and should not be merged until `ovos-media#153` lands and the ecosystem is ready for it.